### PR TITLE
perf: reduce Combo result transfer and first-render overhead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,7 @@ jobs:
       - name: eslint
         working-directory: frontend
         run: npm run lint
+
+      - name: Frontend regression tests
+        working-directory: frontend
+        run: npm test

--- a/backend/combo_transport.py
+++ b/backend/combo_transport.py
@@ -1,0 +1,34 @@
+"""Opt-in wire format for combo results; solver caches keep the legacy shape."""
+
+import json
+from typing import Literal
+
+ComboResponseFormat = Literal["legacy", "items-v1"]
+
+
+def format_combo_result(result: dict, response_format: ComboResponseFormat) -> dict:
+    if response_format == "legacy":
+        return result
+    if response_format != "items-v1":
+        raise ValueError(f"Unknown combo response format: {response_format}")
+
+    items = {}
+    combos = []
+    for combo in result["combos"]:
+        parent = combo["parent_item"]
+        children = combo["child_items"]
+        items[parent["id"]] = parent
+        for child in children:
+            items[child["id"]] = child
+        # Preserve slot/owner arrays (including repeated IDs) and every stat.
+        compact = {key: value for key, value in combo.items() if key not in ("parent_item", "child_items")}
+        compact["parent_item_id"] = parent["id"]
+        compact["child_item_ids"] = [child["id"] for child in children]
+        combos.append(compact)
+    return {**result, "response_format": "items-v1", "items": items, "combos": combos}
+
+
+def combo_result_event(result: dict, response_format: ComboResponseFormat) -> str:
+    event = {"type": "result", "data": format_combo_result(result, response_format)}
+    separators = (",", ":") if response_format == "items-v1" else None
+    return f"data: {json.dumps(event, separators=separators)}\n\n"

--- a/backend/main.py
+++ b/backend/main.py
@@ -19,7 +19,7 @@ from fastapi.responses import StreamingResponse
 from starlette.middleware.gzip import GZipMiddleware as GZIPMiddleware
 from sqlalchemy import case, func, text
 from sqlalchemy.orm import Session
-from typing import List, Literal, Optional
+from typing import Annotated, List, Literal, Optional
 
 from database import SessionLocal, engine, Base
 from models_items import Item
@@ -30,6 +30,7 @@ from models_item_offers import ItemOffer  # noqa: F401 - registers table with Ba
 from models_weapon_presets import WeaponDefaultPreset  # noqa: F401 - registers table with Base.metadata
 from stats import _compute_stats, apply_full_mag_ammo
 from compatibility import CompatibilityIndex
+from combo_transport import ComboResponseFormat, combo_result_event, format_combo_result
 from optimizer.solver import optimize_weapon, get_stat_ranges, get_moa_floor, OptimizeParams
 from optimizer.gunsmith import get_gunsmith_tasks, solve_gunsmith_task
 from optimizer.compat_map import build_compatibility_map
@@ -1478,6 +1479,7 @@ def combo_full(
     exclude_child_slot_names: List[str] = Body(default=[]),
     exclude_item_ids: List[str] = Body(default=[]),
     db: Session = Depends(get_db),
+    response_format: Annotated[ComboResponseFormat, Body()] = "legacy",
 ):
     _combo_started = time.perf_counter()
     if not (STRENGTH_LEVEL_MIN <= strength_level <= STRENGTH_LEVEL_MAX):
@@ -1517,7 +1519,7 @@ def combo_full(
         }
 
         def _cached_stream():
-            yield f"data: {json.dumps({'type': 'result', 'data': cached_result})}\n\n"
+            yield combo_result_event(cached_result, response_format)
 
         return StreamingResponse(
             _cached_stream(),
@@ -1572,7 +1574,7 @@ def combo_full(
     base_stats = _compute_stats(base_item, installed_ids, items_map, strength_level, equip_ergo_modifier)
 
     if not all_parents:
-        return {
+        result = {
             "base": base_stats,
             "combos": [],
             "timed_out": False,
@@ -1596,6 +1598,7 @@ def combo_full(
                 "processing_ms": round((time.perf_counter() - _combo_started) * 1000, 3),
             },
         }
+        return format_combo_result(result, response_format)
 
     all_parent_ids = [p.id for p in all_parents]
 
@@ -2060,7 +2063,7 @@ def combo_full(
                     del _COMBO_FULL_CACHE[k]
             _COMBO_FULL_CACHE[_cache_key] = result
 
-        yield f"data: {json.dumps({'type': 'result', 'data': result})}\n\n"
+        yield combo_result_event(result, response_format)
 
     return StreamingResponse(
         _stream(), media_type="text/event-stream", headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"}

--- a/backend/tests/test_combo_transport.py
+++ b/backend/tests/test_combo_transport.py
@@ -1,0 +1,217 @@
+"""Wire compatibility, cache reuse and endpoint boundaries without game data."""
+
+import asyncio
+from copy import deepcopy
+import json
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from combo_transport import combo_result_event, format_combo_result
+from tests.test_reachability_integration import consume, setup_graph
+
+
+@pytest.fixture
+def db():
+    # Import after collection so real-data tests can detect an absent game DB.
+    import main
+
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    main.Base.metadata.create_all(engine)
+    main._clear_solver_caches()
+    with Session(engine) as session:
+        yield session
+    main._clear_solver_caches()
+    engine.dispose()
+
+
+def expand(result):
+    """Reconstruct the public legacy contract, preserving all other fields."""
+    if result.get("response_format") != "items-v1":
+        return result
+    items = result["items"]
+    restored = {k: v for k, v in result.items() if k not in ("response_format", "items", "combos")}
+    restored["combos"] = []
+    for combo in result["combos"]:
+        row = {k: v for k, v in combo.items() if k not in ("parent_item_id", "child_item_ids")}
+        row["parent_item"] = items[combo["parent_item_id"]]
+        row["child_items"] = [items[iid] for iid in combo["child_item_ids"]]
+        restored["combos"].append(row)
+    return restored
+
+
+def test_wire_round_trip_preserves_repeated_placements_and_does_not_mutate_cache():
+    parent = {"id": "p", "name": "父件", "price": None}
+    child = {"id": "c", "name": "子件🔧", "price": 0}
+    combo = {
+        "parent_item": parent,
+        "child_items": [child, child],
+        "child_slot_ids": ["s1", "s2"],
+        "child_slot_parent_item_ids": ["p", "c"],
+        "all_child_slot_ids": ["s1"],
+        "all_nested_slot_ids": ["s2", "s2"],
+        "conflict": {"conflicting_item_id": "external", "conflict_name": "外部"},
+        "total_ergo": 1.23456789,
+    }
+    result = {
+        "base": {"total_weight": 3.0},
+        "combos": [combo, {**combo, "child_items": []}],
+        "timed_out": False,
+        "truncated": True,
+        "truncation_reasons": ["frontier_cap", "nested_expansion_limit"],
+        "metrics": {"frontier_cap_hits": 1},
+    }
+    snapshot = deepcopy(result)
+    legacy = combo_result_event(result, "legacy")
+    assert legacy == f"data: {json.dumps({'type': 'result', 'data': result})}\n\n"
+    wire = json.loads(combo_result_event(result, "items-v1")[6:])["data"]
+    assert list(wire["items"]) == ["p", "c"]
+    assert wire["combos"][0]["child_item_ids"] == ["c", "c"]
+    assert expand(wire) == snapshot
+    assert result == snapshot
+    assert format_combo_result(result, "legacy") is result
+
+
+def test_unknown_format_is_rejected_by_encoder():
+    with pytest.raises(ValueError, match="Unknown combo response format"):
+        format_combo_result({"combos": []}, "future")
+
+
+def request(db, response_format="legacy", **overrides):
+    import main
+
+    args = dict(
+        base_item_id="gun",
+        installed_ids=[],
+        root_slot_id="root",
+        lang="en",
+        strength_level=10,
+        equip_ergo_modifier=0,
+        exclude_child_slot_names=[],
+        exclude_item_ids=[],
+        db=db,
+        response_format=response_format,
+    )
+    args.update(overrides)
+    return asyncio.run(consume(main.combo_full(**args)))
+
+
+@pytest.mark.parametrize("first_format", ["legacy", "items-v1"])
+def test_formats_share_the_solver_cache_and_keep_request_context(db, first_format):
+    import main
+
+    setup_graph(
+        db,
+        {("root", "gun"): ["p"], ("child", "p"): ["a", "b"]},
+        fields={"p": {"name_zh": "父件"}, "installed": {"conflicting_item_ids": "a"}},
+    )
+    first = request(db, first_format, installed_ids=["installed"])
+    assert first["metrics"]["cache_hit"] is False
+    cached_before = deepcopy(main._COMBO_FULL_CACHE)
+    second_format = "items-v1" if first_format == "legacy" else "legacy"
+    # Any attempt to solve again would need to query the graph.
+    with patch.object(db, "query", side_effect=AssertionError("wire format caused another solve")):
+        second = request(db, second_format, installed_ids=["installed"])
+    assert second["metrics"]["cache_hit"] is True
+    assert len(main._COMBO_FULL_CACHE) == 1
+    assert main._COMBO_FULL_CACHE == cached_before
+    a, b = expand(first), expand(second)
+    assert a["combos"] == b["combos"]
+    assert a["base"] == b["base"]
+    assert any(c["conflict"] for c in a["combos"])
+    assert {k: v for k, v in a.items() if k != "metrics"} == {k: v for k, v in b.items() if k != "metrics"}
+    for changes in [
+        {"lang": "zh"},
+        {"strength_level": 51},
+        {"equip_ergo_modifier": -0.1},
+        {"exclude_item_ids": ["a"]},
+        {"exclude_child_slot_names": ["child"]},
+    ]:
+        changed = request(db, "items-v1", installed_ids=["installed"], **changes)
+        assert changed["metrics"]["cache_hit"] is False
+    assert changed["items"]["p"]["name"] == "p"
+    main._clear_solver_caches()
+    assert request(db, "items-v1", installed_ids=["installed"])["metrics"]["cache_hit"] is False
+
+
+@pytest.mark.parametrize("response_format", ["legacy", "items-v1"])
+def test_empty_root_uses_json_and_direct_call_default_stays_legacy(db, response_format):
+    import main
+
+    setup_graph(db, {("root", "gun"): []})
+    result = request(db, response_format)
+    assert result["combos"] == []
+    assert result["truncated"] is False
+    if response_format == "items-v1":
+        assert result["items"] == {}
+        assert result["response_format"] == "items-v1"
+    legacy = main.combo_full("gun", [], "root", "en", 10, 0, [], [], db)
+    assert isinstance(legacy, dict)
+    assert "response_format" not in legacy
+    assert expand(result)["base"] == legacy["base"]
+
+
+def test_compact_format_keeps_frontier_limit_and_truncation_metadata(db):
+    import main
+
+    setup_graph(db, {("root", "gun"): ["p"], ("child", "p"): ["a", "b", "c"]})
+    with patch.object(main, "_COMBO_FRONTIER_CAP", 2):
+        compact = request(db, "items-v1")
+        legacy = request(db)
+    assert compact["truncated"] is True
+    assert compact["truncation_reasons"] == ["frontier_cap"]
+    assert compact["metrics"]["frontier_cap_hits"] > 0
+    assert expand(compact)["combos"] == legacy["combos"]
+
+
+def test_http_rejects_unknown_format_before_solving(db):
+    import main
+
+    async def send_request():
+        sent = False
+        messages = []
+
+        async def receive():
+            nonlocal sent
+            if not sent:
+                sent = True
+                return {
+                    "type": "http.request",
+                    "body": json.dumps(
+                        {
+                            "base_item_id": "gun",
+                            "installed_ids": [],
+                            "root_slot_id": "root",
+                            "response_format": "future",
+                        }
+                    ).encode(),
+                    "more_body": False,
+                }
+            await asyncio.Event().wait()
+
+        async def send(message):
+            messages.append(message)
+
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.4"},
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/build/combo-full",
+            "query_string": b"",
+            "headers": [(b"host", b"localhost"), (b"content-type", b"application/json")],
+            "client": ("127.0.0.1", 9000),
+            "server": ("localhost", 80),
+        }
+        await asyncio.wait_for(main.app(scope, receive, send), 10)
+        assert next(m for m in messages if m["type"] == "http.response.start")["status"] == 422
+        body = b"".join(m.get("body", b"") for m in messages if m["type"] == "http.response.body")
+        assert json.loads(body)["detail"][0]["loc"] == ["body", "response_format"]
+
+    with patch.dict(main.app.dependency_overrides, {main.get_db: lambda: db}):
+        asyncio.run(send_request())
+    assert not main._COMBO_FULL_CACHE

--- a/frontend/modules/api.js
+++ b/frontend/modules/api.js
@@ -119,35 +119,78 @@ async function comboFull(payload, signal, onProgress) {
     const res = await fetch(`${_base()}/build/combo-full`, {
         method:  "POST",
         headers: { "Content-Type": "application/json" },
-        body:    JSON.stringify(payload),
+        body:    JSON.stringify({ response_format: "items-v1", ...payload }),
         signal,
     });
     if (!res.ok) throw new Error(`Server error: ${res.status}`);
 
-    const reader  = res.body.getReader();
-    const decoder = new TextDecoder();
-    let buf = "";
-
-    while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buf += decoder.decode(value, { stream: true });
-        const parts = buf.split("\n\n");
-        buf = parts.pop() ?? "";
-        for (const part of parts) {
-            const line = part.split("\n").find(l => l.startsWith("data: "));
-            if (!line) continue;
-            const event = JSON.parse(line.slice(6));
-            if (event.type === "progress") {
-                onProgress?.(event);
-            } else if (event.type === "result") {
-                return event.data;
-            } else if (event.type === "error") {
-                throw new Error(event.message ?? "combo-full stream error");
-            }
-        }
+    const checkAbort = () => {
+        if (signal?.aborted) throw signal.reason ?? new DOMException("Aborted", "AbortError");
+    };
+    // Empty candidate sets use a normal JSON response, including on older servers.
+    if (res.headers.get("content-type")?.split(";")[0].trim() === "application/json") {
+        const result = await res.json();
+        checkAbort();
+        return result;
     }
-    throw new Error("combo-full stream ended without result");
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let fragments = [];
+    let dataLines = [];
+    let skipLF = false;
+    const acceptLine = line => {
+        if (line === "") {
+            if (!dataLines.length) return null;
+            const event = JSON.parse(dataLines.join("\n"));
+            dataLines = [];
+            return event;
+        }
+        if (line.startsWith("data:")) dataLines.push(line.slice(line[5] === " " ? 6 : 5));
+        return null;
+    };
+    try {
+        while (true) {
+            checkAbort();
+            const { done, value } = await reader.read();
+            checkAbort();
+            if (done) break;
+            const text = decoder.decode(value, { stream: true });
+            let from = 0;
+            if (skipLF && text.length) {
+                if (text[0] === "\n") from = 1;
+                skipLF = false;
+            }
+            // Scan only this chunk. A large unfinished JSON line is joined once,
+            // when its terminator arrives, instead of copied/scanned on every read.
+            const breaks = /[\r\n]/g;
+            breaks.lastIndex = from;
+            let match;
+            while ((match = breaks.exec(text))) {
+                fragments.push(text.slice(from, match.index));
+                const line = fragments.length === 1 ? fragments[0] : fragments.join("");
+                fragments = [];
+                from = match.index + 1;
+                if (match[0] === "\r") {
+                    if (text[from] === "\n") from++;
+                    else if (from === text.length) skipLF = true;
+                }
+                breaks.lastIndex = from;
+                const event = acceptLine(line);
+                if (!event) continue;
+                if (event.type === "progress") onProgress?.(event);
+                checkAbort();
+                if (event.type === "result") return event.data;
+                if (event.type === "error") throw new Error(event.message ?? "combo-full stream error");
+            }
+            if (from < text.length) fragments.push(text.slice(from));
+        }
+        throw new Error("combo-full stream ended without result");
+    } finally {
+        fragments = dataLines = [];
+        try { await reader.cancel(); } catch { /* Preserve the original error. */ }
+        reader.releaseLock();
+    }
 }
 
 // tarkov.dev's JSON API serves the full item list per game mode (avg24hPrice

--- a/frontend/modules/slot-selector.js
+++ b/frontend/modules/slot-selector.js
@@ -1771,6 +1771,7 @@ const _comboChildSlotCache   = {};   // item_id -> slots[]  (used only for avail
 let _comboAvailableChecked = false; // true once we've finished the availability check for the current slot
 let _comboAbortController  = null;  // AbortController for the in-flight comboFull request
 let _comboCalcInFlight     = false; // true while a comboFull fetch is in progress
+let _comboRequestGen       = 0;     // only the current request may update the view
 
 const _COMBO_BATCH_SIZE  = 60;
 let _comboLazyItems      = [];   // full sorted list for lazy rendering
@@ -1797,6 +1798,7 @@ function _disconnectComboObserver() {
 }
 
 function _abortComboCalc() {
+    _comboRequestGen++;
     if (_comboAbortController) {
         _comboAbortController.abort();
         _comboAbortController = null;
@@ -1946,6 +1948,10 @@ function _showComboToggle(visible) {
 
 async function openComboView() {
     if (!EFTForge.state.lastSlot || !EFTForge.state.lastParentNode) return;
+    // Cache hits and already-resolved fetches must also invalidate the old request.
+    _abortComboCalc();
+    const requestGen = _comboRequestGen;
+    _disconnectComboObserver();
 
     const { t } = EFTForge.lang;
 
@@ -1994,6 +2000,8 @@ async function openComboView() {
         return;
     }
 
+    EFTForge.state.lastComboItems = [];
+    EFTForge.state.lastComboWasCapped = false;
     const tbody = document.getElementById("attachment-body");
     if (tbody) {
         _clearMarqueeTimers();
@@ -2007,19 +2015,21 @@ async function openComboView() {
     let _loadingDots = 1;
     const _loadingBaseText = t("ui.comboLoading");
     const _dotsInterval = setInterval(() => {
+        if (requestGen !== _comboRequestGen) return;
         const el = document.getElementById("combo-loading-main");
         if (el) el.textContent = _loadingBaseText + ".".repeat(_loadingDots);
         _loadingDots = _loadingDots >= 3 ? 1 : _loadingDots + 1;
     }, 500);
 
-    _abortComboCalc();
     _comboAbortController = new AbortController();
     _comboCalcInFlight = true;
     const signal = _comboAbortController.signal;
 
     let result;
+    let processedCombos;
     try {
         result = await comboFull(comboRequest, signal, (ev) => {
+            if (requestGen !== _comboRequestGen) return;
             const progressEl = document.getElementById("combo-loading-progress");
             if (!progressEl) return;
             const text = t(ev.capped ? "ui.comboProgressCapped" : "ui.comboProgress")
@@ -2029,10 +2039,10 @@ async function openComboView() {
                 .replace("{cap}",      ev.cap);
             progressEl.textContent = text;
         });
+        if (requestGen !== _comboRequestGen || !EFTForge.state.comboMode) return;
+        processedCombos = _prepareComboItems(result);
     } catch (err) {
-        _comboCalcInFlight = false;
-        clearInterval(_dotsInterval);
-        if (err.name === "AbortError") return;
+        if (requestGen !== _comboRequestGen || err.name === "AbortError") return;
         console.error("Combo full failed:", err);
         if (tbody && EFTForge.state.comboMode) {
             tbody.innerHTML = `<tr><td colspan="10" class="combo-status-row combo-error">${escapeHtml(t("ui.comboError"))}</td></tr>`;
@@ -2040,21 +2050,51 @@ async function openComboView() {
         EFTForge.state.comboMode = false;
         _updateViewBtns();
         return;
+    } finally {
+        clearInterval(_dotsInterval);
+        if (requestGen === _comboRequestGen) {
+            _comboCalcInFlight = false;
+            _comboAbortController = null;
+        }
     }
-
-    _comboCalcInFlight = false;
-    clearInterval(_dotsInterval);
 
     if (result.truncated) {
         showToast(t("ui.comboTruncatedTitle"), t("ui.comboTruncatedMsg"), 8000, "#f5a623");
     }
 
-    if (!EFTForge.state.comboMode) return;
+    EFTForge.state.combosCache[cacheKey] = {
+        items: processedCombos,
+        truncated: !!result.truncated,
+        truncationReasons: result.truncation_reasons ?? [],
+    };
+    EFTForge.state.lastComboItems        = processedCombos;
+    EFTForge.state.lastComboWasCapped    = !!result.truncated;
 
-    if (!result.combos.length) {
-        if (tbody) tbody.innerHTML = `<tr><td colspan="10" class="combo-status-row">${escapeHtml(t("ui.comboNone"))}</td></tr>`;
-        return;
+    applyComboSort();
+}
+
+function _prepareComboItems(result) {
+    const compact = result.response_format === "items-v1";
+    if ((result.response_format != null && result.response_format !== "legacy" && !compact)
+        || !Array.isArray(result.combos)) {
+        throw new Error("Invalid combo response format");
     }
+    const resolveItem = id => {
+        const item = result.items?.[id];
+        if (!item || item.id !== id) throw new Error(`Missing combo item: ${id}`);
+        return item;
+    };
+    // Prices depend on the current market/player settings. Memoize only within
+    // this preparation, never across requests or settings changes.
+    const metadata = new Map();
+    const itemMeta = item => {
+        let entry = metadata.get(item.id);
+        if (!entry) {
+            entry = { price: _getPriceRub(item), name: item.name.toLowerCase() };
+            metadata.set(item.id, entry);
+        }
+        return entry;
+    };
 
     const base       = result.base;
     const baseEED     = parseFloat(base.evo_ergo_delta ?? 0);
@@ -2062,7 +2102,9 @@ async function openComboView() {
     const baseErgo    = parseFloat(base.total_ergo ?? 0);
     const baseWeight  = parseFloat(base.total_weight ?? 0);
 
-    const processedCombos = result.combos.map(combo => {
+    return result.combos.map(combo => {
+        const parent = compact ? resolveItem(combo.parent_item_id) : combo.parent_item;
+        const children = compact ? combo.child_item_ids.map(resolveItem) : combo.child_items;
         const simEED     = parseFloat(combo.evo_ergo_delta ?? 0);
         const simErgo    = parseFloat(combo.total_ergo ?? 0);
         const simWeight  = parseFloat(combo.total_weight ?? 0);
@@ -2073,14 +2115,16 @@ async function openComboView() {
         const comboWeightDelta = simWeight - baseWeight;
         const comboRecoilPct   = (baseRecoilV && simRecoilV !== null)
             ? (simRecoilV / baseRecoilV - 1) * 100
-            : parseFloat(combo.parent_item.recoil_modifier ?? 0) * 100
-              + combo.child_items.reduce((s, ci) => s + parseFloat(ci.recoil_modifier ?? 0) * 100, 0);
+            : parseFloat(parent.recoil_modifier ?? 0) * 100
+              + children.reduce((s, ci) => s + parseFloat(ci.recoil_modifier ?? 0) * 100, 0);
 
         let totalPrice = 0; let hasPrice = false;
-        for (const item of [combo.parent_item, ...combo.child_items]) {
-            const p = _getPriceRub(item);
+        let sortName = itemMeta(parent).name;
+        for (const item of [parent, ...children]) {
+            const p = itemMeta(item).price;
             if (p !== null) { totalPrice += p; hasPrice = true; }
         }
+        for (const child of children) sortName += " " + itemMeta(child).name;
         const finalPrice = hasPrice ? totalPrice : null;
 
         // ₽/Recoil: rubles per 1% recoil reduction; null when no price or no recoil reduction
@@ -2088,14 +2132,11 @@ async function openComboView() {
             ? finalPrice / Math.abs(comboRecoilPct)
             : null;
 
-        const sortName = combo.parent_item.name.toLowerCase()
-            + combo.child_items.map(ci => " " + ci.name.toLowerCase()).join("");
-
         return {
-            parentEntry:                { item: combo.parent_item, hasConflict: false,
-                                          recoilPercent: parseFloat(combo.parent_item.recoil_modifier ?? 0) * 100,
-                                          sortName: combo.parent_item.name.toLowerCase() },
-            childItems:                 combo.child_items,
+            parentEntry:                { item: parent, hasConflict: false,
+                                          recoilPercent: parseFloat(parent.recoil_modifier ?? 0) * 100,
+                                          sortName: itemMeta(parent).name },
+            childItems:                 children,
             childSlotIds:               combo.child_slot_ids,
             childSlotParentItemIds:     combo.child_slot_parent_item_ids ?? [],
             allChildSlotIds:            combo.all_child_slot_ids,
@@ -2107,16 +2148,6 @@ async function openComboView() {
             comboRublePerRecoil,
         };
     });
-
-    EFTForge.state.combosCache[cacheKey] = {
-        items: processedCombos,
-        truncated: !!result.truncated,
-        truncationReasons: result.truncation_reasons ?? [],
-    };
-    EFTForge.state.lastComboItems        = processedCombos;
-    EFTForge.state.lastComboWasCapped    = !!result.truncated;
-
-    applyComboSort();
 }
 
 function applyComboSort() {
@@ -2191,13 +2222,21 @@ function _updateComboColumnVisibility(items) {
     const table = document.querySelector(".attachment-table");
     if (!table) return;
 
-    const allItems = items.flatMap(e => [e.parentEntry.item, ...e.childItems]);
-
-    const hasWeight = allItems.some(it => parseFloat(it.weight ?? 0) !== 0);
-    const hasRecoil = allItems.some(it => it.recoil_modifier != null && it.recoil_modifier !== 0);
-    const hasErgo   = allItems.some(it => it.ergonomics_modifier != null && it.ergonomics_modifier !== 0);
-    const hasEvo    = hasErgo && items.some(e => Math.abs(e.comboEEDDelta) > 0.05);
-    const hasPrice  = items.some(e => e.totalPrice !== null);
+    let hasWeight = false, hasRecoil = false, hasErgo = false, hasEED = false, hasPrice = false;
+    for (const entry of items) {
+        hasEED ||= Math.abs(entry.comboEEDDelta) > 0.05;
+        hasPrice ||= entry.totalPrice !== null;
+        if (!hasWeight || !hasRecoil || !hasErgo) {
+            for (const item of [entry.parentEntry.item, ...entry.childItems]) {
+                hasWeight ||= parseFloat(item.weight ?? 0) !== 0;
+                hasRecoil ||= item.recoil_modifier != null && item.recoil_modifier !== 0;
+                hasErgo   ||= item.ergonomics_modifier != null && item.ergonomics_modifier !== 0;
+                if (hasWeight && hasRecoil && hasErgo) break;
+            }
+        }
+        if (hasWeight && hasRecoil && hasErgo && hasEED && hasPrice) break;
+    }
+    const hasEvo = hasErgo && hasEED;
 
     table.classList.toggle("hide-col-weight", !hasWeight);
     table.classList.toggle("hide-col-recoil", !hasRecoil);

--- a/frontend/modules/slot-selector.js
+++ b/frontend/modules/slot-selector.js
@@ -1951,6 +1951,9 @@ async function openComboView() {
     // Cache hits and already-resolved fetches must also invalidate the old request.
     _abortComboCalc();
     const requestGen = _comboRequestGen;
+    const requestTree = EFTForge.state.buildTree;
+    const requestSlot = EFTForge.state.lastSlot;
+    const requestParent = EFTForge.state.lastParentNode;
     _disconnectComboObserver();
 
     const { t } = EFTForge.lang;
@@ -1978,6 +1981,17 @@ async function openComboView() {
                                       ? _AG_LEFT_ORDER.filter(n => n !== EFTForge.state.lastSlot?.slot_name) : [],
         exclude_item_ids:          EFTForge.config.COMBO_EXCLUDE_ITEM_IDS ?? [],
     };
+    // Gun/tab switches clear the slot without necessarily starting another
+    // combo request. Its old response must not populate that new context either.
+    const isCurrentRequest = () => requestGen === _comboRequestGen
+        && EFTForge.state.comboMode
+        && EFTForge.state.buildTree === requestTree
+        && EFTForge.state.lastSlot === requestSlot
+        && EFTForge.state.lastParentNode === requestParent
+        && EFTForge.state.currentGun?.id === comboRequest.base_item_id
+        && _lang() === comboRequest.lang
+        && (EFTForge.state.currentStrengthLevel ?? 10) === comboRequest.strength_level
+        && (EFTForge.state.currentEquipErgoModifier ?? 0) === comboRequest.equip_ergo_modifier;
     const cacheKey = `combo__${JSON.stringify({
         base_item_id: comboRequest.base_item_id,
         root_slot_id: comboRequest.root_slot_id,
@@ -2015,7 +2029,7 @@ async function openComboView() {
     let _loadingDots = 1;
     const _loadingBaseText = t("ui.comboLoading");
     const _dotsInterval = setInterval(() => {
-        if (requestGen !== _comboRequestGen) return;
+        if (!isCurrentRequest()) return;
         const el = document.getElementById("combo-loading-main");
         if (el) el.textContent = _loadingBaseText + ".".repeat(_loadingDots);
         _loadingDots = _loadingDots >= 3 ? 1 : _loadingDots + 1;
@@ -2029,7 +2043,7 @@ async function openComboView() {
     let processedCombos;
     try {
         result = await comboFull(comboRequest, signal, (ev) => {
-            if (requestGen !== _comboRequestGen) return;
+            if (!isCurrentRequest()) return;
             const progressEl = document.getElementById("combo-loading-progress");
             if (!progressEl) return;
             const text = t(ev.capped ? "ui.comboProgressCapped" : "ui.comboProgress")
@@ -2039,10 +2053,10 @@ async function openComboView() {
                 .replace("{cap}",      ev.cap);
             progressEl.textContent = text;
         });
-        if (requestGen !== _comboRequestGen || !EFTForge.state.comboMode) return;
+        if (!isCurrentRequest()) return;
         processedCombos = _prepareComboItems(result);
     } catch (err) {
-        if (requestGen !== _comboRequestGen || err.name === "AbortError") return;
+        if (!isCurrentRequest() || err.name === "AbortError") return;
         console.error("Combo full failed:", err);
         if (tbody && EFTForge.state.comboMode) {
             tbody.innerHTML = `<tr><td colspan="10" class="combo-status-row combo-error">${escapeHtml(t("ui.comboError"))}</td></tr>`;

--- a/frontend/modules/slot-selector.js
+++ b/frontend/modules/slot-selector.js
@@ -1983,13 +1983,13 @@ async function openComboView() {
     };
     // Gun/tab switches clear the slot without necessarily starting another
     // combo request. Its old response must not populate that new context either.
-    const isCurrentRequest = () => requestGen === _comboRequestGen
+    const isCurrentView = () => requestGen === _comboRequestGen
         && EFTForge.state.comboMode
         && EFTForge.state.buildTree === requestTree
         && EFTForge.state.lastSlot === requestSlot
         && EFTForge.state.lastParentNode === requestParent
-        && EFTForge.state.currentGun?.id === comboRequest.base_item_id
-        && _lang() === comboRequest.lang
+        && EFTForge.state.currentGun?.id === comboRequest.base_item_id;
+    const isCurrentRequest = () => isCurrentView() && _lang() === comboRequest.lang
         && (EFTForge.state.currentStrengthLevel ?? 10) === comboRequest.strength_level
         && (EFTForge.state.currentEquipErgoModifier ?? 0) === comboRequest.equip_ergo_modifier;
     const cacheKey = `combo__${JSON.stringify({
@@ -2053,10 +2053,19 @@ async function openComboView() {
                 .replace("{cap}",      ev.cap);
             progressEl.textContent = text;
         });
-        if (!isCurrentRequest()) return;
+        if (!isCurrentRequest()) {
+            // A setting changed while receiving: refresh the same view with its
+            // current inputs instead of leaving a finished loading row behind.
+            if (isCurrentView()) return openComboView();
+            return;
+        }
         processedCombos = _prepareComboItems(result);
     } catch (err) {
-        if (!isCurrentRequest() || err.name === "AbortError") return;
+        if (!isCurrentRequest()) {
+            if (isCurrentView()) return openComboView();
+            return;
+        }
+        if (err.name === "AbortError") return;
         console.error("Combo full failed:", err);
         if (tbody && EFTForge.state.comboMode) {
             tbody.innerHTML = `<tr><td colspan="10" class="combo-status-row combo-error">${escapeHtml(t("ui.comboError"))}</td></tr>`;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "eftforge-frontend",
   "private": true,
   "scripts": {
+    "test": "node --test tests/*.test.js",
     "lint": "eslint . --ext .js --ignore-pattern lzstring.min.js --ignore-pattern marked.min.js -c ../.eslintrc.json"
   },
   "devDependencies": {

--- a/frontend/tests/combo-api.test.js
+++ b/frontend/tests/combo-api.test.js
@@ -1,0 +1,115 @@
+/* eslint-env node */
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const source = fs.readFileSync(path.join(__dirname, "../modules/api.js"), "utf8");
+const plain = value => JSON.parse(JSON.stringify(value));
+const data = { combos: [{ name: "中文🔧", path: ["same", "same"] }], truncated: true };
+const progress = { type: "progress", slot: "枪托", frontier: 17, capped: true };
+const stream = `: heartbeat\n\ndata: ${JSON.stringify(progress)}\n\ndata: ${JSON.stringify({ type: "result", data })}\n\n`;
+
+function request(text, sizes = [3], options = {}) {
+    const EFTForge = { config: { API_BASE: "" }, state: {} };
+    const ctx = vm.createContext({ window: { EFTForge }, EFTForge, TextDecoder, DOMException });
+    vm.runInContext(source, ctx);
+    const bytes = Buffer.from(text);
+    const controller = new AbortController();
+    let offset = 0, reads = 0, cancels = 0, releases = 0;
+    let posted;
+    const events = [];
+    ctx.fetch = async (url, init) => {
+        posted = JSON.parse(init.body);
+        assert.equal(init.signal, controller.signal);
+        return {
+            ok: options.status == null, status: options.status,
+            headers: new Map([["content-type", options.json ? "application/json; charset=utf-8" : "text/event-stream"]]),
+            async json() {
+                if (options.abortJSON) controller.abort();
+                return JSON.parse(text);
+            },
+            body: { getReader: () => ({
+                async read() {
+                    if (options.abortRead === reads) controller.abort();
+                    if (options.failRead === reads) throw new TypeError("read failed");
+                    if (offset === bytes.length) return { done: true };
+                    const size = sizes[reads++ % sizes.length];
+                    const value = bytes.subarray(offset, offset + size);
+                    offset += value.length;
+                    return { done: false, value };
+                },
+                async cancel() {
+                    cancels++;
+                    if (options.failCancel) throw new Error("cancel failed");
+                },
+                releaseLock() { releases++; },
+            }) },
+        };
+    };
+    if (options.preAbort) controller.abort();
+    const promise = ctx.comboFull(options.payload ?? {}, controller.signal, event => {
+        events.push(plain(event));
+        if (options.abortProgress) controller.abort();
+    });
+    return { promise, events, counts: () => ({ cancels, releases }), posted: () => posted };
+}
+
+for (const sizes of [[1], [2], [3], [7], [65536], [1, 8, 2, 19]]) {
+    for (const ending of ["\n", "\r\n", "\r"]) {
+        test(`UTF-8, progress and delimiters: chunks ${sizes}, newline ${JSON.stringify(ending)}`, async () => {
+            const run = request(stream.replaceAll("\n", ending), sizes);
+            assert.deepEqual(plain(await run.promise), data);
+            assert.deepEqual(run.events, [progress]);
+            assert.deepEqual(run.counts(), { cancels: 1, releases: 1 });
+            assert.equal(run.posted().response_format, "items-v1");
+        });
+    }
+}
+
+test("multiline SSE data, ignored fields and explicit legacy request", async () => {
+    const run = request('event: message\nid: 1\ndata:{"type":"result",\ndata: "data":{"combos":[]}}\n\n', [2],
+        { payload: { response_format: "legacy" } });
+    assert.deepEqual(plain(await run.promise), { combos: [] });
+    assert.equal(run.posted().response_format, "legacy");
+});
+
+test("one large result with many small reads", async () => {
+    const large = { items: { item: { name: "长".repeat(200000) } }, combos: [], response_format: "items-v1" };
+    const run = request(`data: ${JSON.stringify({ type: "result", data: large })}\n\n`, [127]);
+    assert.deepEqual(plain(await run.promise), large);
+});
+
+for (const [name, text, options, error] of [
+    ["EOF before delimiter", 'data: {"type":"result","data":{}}', {}, /ended without result/],
+    ["EOF after progress", `data: ${JSON.stringify(progress)}\n\n`, {}, /ended without result/],
+    ["server stream error", 'data: {"type":"error","message":"sample failure"}\n\n', {}, /sample failure/],
+    ["malformed JSON", "data: broken\n\n", { failCancel: true }, { name: "SyntaxError" }],
+    ["abort during read", stream, { abortRead: 2 }, { name: "AbortError" }],
+    ["already aborted", stream, { preAbort: true }, { name: "AbortError" }],
+    ["abort from progress in the same chunk", stream, { abortProgress: true }, { name: "AbortError" }],
+    ["network error", stream, { failRead: 0, failCancel: true }, /read failed/],
+]) {
+    test(`${name} releases the reader and preserves the error`, async () => {
+        const run = request(text, options.abortProgress ? [65536] : [3], options);
+        await assert.rejects(run.promise, error);
+        assert.deepEqual(run.counts(), { cancels: 1, releases: 1 });
+    });
+}
+
+for (const response_format of [undefined, "items-v1"]) {
+    test(`ordinary JSON empty response: ${response_format ?? "legacy"}`, async () => {
+        const value = { base: {}, combos: [], response_format };
+        const run = request(JSON.stringify(value), [3], { json: true });
+        assert.deepEqual(plain(await run.promise), plain(value));
+        assert.deepEqual(run.counts(), { cancels: 0, releases: 0 });
+    });
+}
+
+test("JSON abort and HTTP failure do not return a result", async () => {
+    await assert.rejects(request("{}", [3], { json: true, abortJSON: true }).promise, { name: "AbortError" });
+    const run = request("", [3], { status: 422 });
+    await assert.rejects(run.promise, /Server error: 422/);
+    assert.deepEqual(run.counts(), { cancels: 0, releases: 0 });
+});

--- a/frontend/tests/combo-view.test.js
+++ b/frontend/tests/combo-view.test.js
@@ -1,0 +1,212 @@
+/* eslint-env node */
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const source = fs.readFileSync(path.join(__dirname, "../modules/slot-selector.js"), "utf8");
+const plain = value => JSON.parse(JSON.stringify(value));
+
+function view() {
+    const pending = [], toasts = [], errors = [], renders = [];
+    const nodes = new Map(), intervals = new Map(), classes = new Set();
+    let nextInterval = 0;
+    const classList = {
+        toggle(name, enabled) { if (enabled) classes.add(name); else classes.delete(name); },
+        add(name) { classes.add(name); }, remove(name) { classes.delete(name); },
+    };
+    const root = { item: { id: "gun" }, children: {} };
+    const state = { lastSlot: { id: "A", slot_name: "Stock" }, lastParentNode: root, buildTree: root,
+        currentGun: root.item, combosCache: {}, lastComboItems: [], comboMode: true,
+        traderLevels: {}, comboSort: { key: "recoil", direction: "asc" }, comboErgoWeight: 50 };
+    const EFTForge = { state, config: {}, lang: { t: x => x } };
+    const ctx = vm.createContext({ window: { EFTForge }, EFTForge, AbortController, DOMException,
+        console: { error: (...args) => errors.push(args) },
+        document: {
+            getElementById(id) {
+                if (!nodes.has(id)) nodes.set(id, { style: {}, classList, textContent: "", innerHTML: "" });
+                return nodes.get(id);
+            },
+            querySelector(selector) { return selector === ".attachment-table" ? { classList } : null; },
+        },
+        collectAttachmentIds: () => [], _lang: () => "en", escapeHtml: x => x,
+        showToast: (...args) => toasts.push(args),
+        setInterval: callback => { intervals.set(++nextInterval, callback); return nextInterval; },
+        clearInterval: id => intervals.delete(id),
+    });
+    vm.runInContext(source, ctx);
+    ctx._findComboRootSlot = () => ({ parentNode: root, slotId: state.lastSlot.id, isLeftQueueRoot: false });
+    ctx._clearMarqueeTimers = () => {};
+    ctx.updateSortIndicators = () => {};
+    ctx._renderComboRows = items => renders.push(plain(items));
+    ctx.comboFull = (payload, signal, onProgress) => new Promise((resolve, reject) => {
+        pending.push({ payload, signal, onProgress, resolve, reject });
+        signal.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), { once: true });
+    });
+    const select = id => { state.lastSlot = { id, slot_name: "Stock" }; return ctx.openComboView(); };
+    const inFlight = () => vm.runInContext("_comboCalcInFlight", ctx);
+    return { ctx, state, pending, nodes, intervals, classes, toasts, errors, renders, select, inFlight };
+}
+
+function result(id, truncated = false) {
+    return { base: {}, combos: [{ parent_item: { id, name: id }, child_items: [],
+        child_slot_ids: [], all_child_slot_ids: [], total_ergo: 1 }], truncated,
+        truncation_reasons: truncated ? ["frontier_cap"] : [] };
+}
+
+function compact(result) {
+    const items = {};
+    const combos = result.combos.map(({ parent_item, child_items, ...rest }) => {
+        for (const item of [parent_item, ...child_items]) items[item.id] = item;
+        return { ...rest, parent_item_id: parent_item.id, child_item_ids: child_items.map(item => item.id) };
+    });
+    return { ...result, response_format: "items-v1", items, combos };
+}
+
+test("aborted request cannot clear the next request's loading flag or progress", async () => {
+    const v = view();
+    const a = v.select("A"), oldDots = [...v.intervals.values()][0];
+    const b = v.select("B");
+    const text = v.nodes.get("attachment-body").innerHTML;
+    await a;
+    assert.equal(v.inFlight(), true);
+    assert.equal(v.pending[1].signal.aborted, false);
+    v.pending[0].onProgress({ capped: true });
+    oldDots();
+    assert.equal(v.nodes.has("combo-loading-progress"), false);
+    assert.equal(v.nodes.has("combo-loading-main"), false);
+    v.ctx.applyComboSort();
+    assert.equal(v.nodes.get("attachment-body").innerHTML, text);
+    v.pending[1].resolve(compact(result("B", true)));
+    await b;
+    assert.equal(v.state.lastComboItems[0].parentEntry.item.id, "B");
+    assert.equal(v.toasts.length, 1);
+    assert.equal(v.inFlight(), false);
+    assert.equal(v.intervals.size, 0);
+});
+
+test("a resolved stale request cannot write results, cache or truncation toasts", async () => {
+    const v = view(), a = v.select("A");
+    v.pending[0].resolve(result("A", true));
+    const b = v.select("B");
+    await a;
+    assert.equal(v.state.lastComboItems.length, 0);
+    assert.equal(Object.keys(v.state.combosCache).length, 0);
+    assert.equal(v.toasts.length, 0);
+    assert.equal(v.inFlight(), true);
+    v.pending[1].resolve(result("B"));
+    await b;
+    assert.equal(v.state.lastComboItems[0].parentEntry.item.id, "B");
+});
+
+test("a cache hit invalidates an in-flight request", async () => {
+    const v = view(), initial = v.select("B");
+    v.pending[0].resolve(result("B"));
+    await initial;
+    const a = v.select("A");
+    v.pending[1].resolve(result("A", true));
+    await v.select("B");
+    await a;
+    assert.equal(v.pending.length, 2);
+    assert.equal(v.state.lastComboItems[0].parentEntry.item.id, "B");
+    assert.equal(v.state.lastComboWasCapped, false);
+    assert.equal(v.toasts.length, 0);
+    assert.equal(v.inFlight(), false);
+});
+
+test("leaving combo view and stale errors cannot change the current view", async () => {
+    const v = view(), a = v.select("A");
+    v.pending[0].reject(new Error("late server error"));
+    v.ctx._abortComboCalc();
+    v.state.comboMode = false;
+    v.nodes.get("attachment-body").innerHTML = "new view";
+    await a;
+    assert.equal(v.nodes.get("attachment-body").innerHTML, "new view");
+    assert.equal(v.errors.length, 0);
+    assert.equal(v.intervals.size, 0);
+});
+
+test("empty results clear old rows and remain empty when sorted or cached", async () => {
+    const v = view();
+    v.state.lastComboItems = [{ stale: true }];
+    const request = v.select("A");
+    v.pending[0].resolve({ base: {}, combos: [], response_format: "items-v1", items: {} });
+    await request;
+    await v.select("A");
+    assert.equal(v.pending.length, 1);
+    assert.equal(v.state.lastComboItems.length, 0);
+    assert.match(v.nodes.get("attachment-body").innerHTML, /ui.comboNone/);
+});
+
+for (const value of [
+    { ...result("A"), response_format: "future" },
+    { ...compact(result("A")), items: {} },
+    { ...compact(result("A")), items: { A: { id: "other", name: "wrong" } } },
+    { ...result("A"), combos: null },
+]) {
+    test("malformed result follows the view's error path", async () => {
+        const v = view(), request = v.select("A");
+        v.pending[0].resolve(value);
+        await request;
+        assert.equal(v.errors.length, 1);
+        assert.equal(v.state.comboMode, false);
+        assert.equal(v.inFlight(), false);
+        assert.equal(v.intervals.size, 0);
+        assert.equal(Object.keys(v.state.combosCache).length, 0);
+        assert.match(v.nodes.get("attachment-body").innerHTML, /ui.comboError/);
+    });
+}
+
+test("formats preserve repeated placements, stats, conflicts and current-setting prices", () => {
+    const { ctx, state } = view();
+    const parent = Object.freeze({ id: "p", name: "Parent", recoil_modifier: -0.1,
+        trader_vendor: "mechanic", trader_min_level: 2, trader_price_rub: 100 });
+    const child = Object.freeze({ id: "c", name: "子件", recoil_modifier: -0.05 });
+    const legacy = { base: { total_ergo: 20, total_weight: 2, evo_ergo_delta: 4, recoil_vertical: 100 },
+        combos: [{ parent_item: parent, child_items: [child, child], child_slot_ids: ["s1", "s2"],
+            child_slot_parent_item_ids: ["p", "c"], all_child_slot_ids: ["s1"], all_nested_slot_ids: ["s2"],
+            total_ergo: 24, total_weight: 3, evo_ergo_delta: 6, recoil_vertical: 80, recoil_horizontal: 90,
+            conflict: { conflicting_item_id: "x", conflict_name: "外部配件" } }] };
+    const wire = compact(legacy), snapshot = JSON.stringify(wire);
+    state.fleaCachePvp = { c: 50 };
+    const actual = ctx._prepareComboItems(wire);
+    assert.deepEqual(plain(actual), plain(ctx._prepareComboItems(legacy)));
+    const entry = actual[0];
+    assert.equal(entry.childItems[0], entry.childItems[1]);
+    assert.deepEqual(plain(entry.childSlotIds), ["s1", "s2"]);
+    assert.deepEqual(plain(entry.childSlotParentItemIds), ["p", "c"]);
+    assert.deepEqual([entry.simErgo, entry.comboErgoDelta, entry.comboWeightDelta, entry.comboEEDDelta], [24, 4, 1, 2]);
+    assert.ok(Math.abs(entry.comboRecoilPct + 20) < 1e-10);
+    assert.equal(entry.totalPrice, 200);
+    assert.ok(Math.abs(entry.comboRublePerRecoil - 10) < 1e-10);
+    assert.equal(entry.sortName, "parent 子件 子件");
+    assert.deepEqual(plain(entry.conflict), legacy.combos[0].conflict);
+    state.pveMode = true;
+    state.fleaCachePve = { p: 40, c: 20 };
+    assert.equal(ctx._prepareComboItems(wire)[0].totalPrice, 80);
+    state.fleaCachePve = {};
+    state.traderLevels.mechanic = 1;
+    assert.equal(ctx._prepareComboItems(wire)[0].totalPrice, null);
+    state.fleaCachePve = { c: 0 };
+    assert.equal(ctx._prepareComboItems(wire)[0].totalPrice, 0);
+    assert.equal(JSON.stringify(wire), snapshot);
+    delete legacy.base.recoil_vertical;
+    assert.equal(ctx._prepareComboItems(compact(legacy))[0].comboRecoilPct, -20);
+});
+
+test("visibility uses only displayed combos and combines evidence across rows", () => {
+    const { ctx, classes } = view();
+    const entry = (item, delta = 0, price = null) => ({ parentEntry: { item }, childItems: [], comboEEDDelta: delta, totalPrice: price });
+    ctx._updateComboColumnVisibility([entry({ weight: 1 }, 1), entry({ recoil_modifier: -0.1, ergonomics_modifier: 2 }, 0, 0)]);
+    for (const name of ["weight", "recoil", "ergo", "evo", "price", "rub-recoil", "balance"]) {
+        assert.equal(classes.has(`hide-col-${name}`), false, name);
+    }
+    ctx._updateComboColumnVisibility([entry({ weight: "0", recoil_modifier: 0, ergonomics_modifier: 0 }, 1)]);
+    for (const name of ["weight", "recoil", "ergo", "evo", "price", "rub-recoil", "balance", "acc", "heat", "vel"]) {
+        assert.equal(classes.has(`hide-col-${name}`), true, name);
+    }
+    ctx._updateComboColumnVisibility([entry({ recoil_modifier: "0", ergonomics_modifier: "0" }, 0.05)]);
+    assert.equal(classes.has("hide-col-recoil"), false); // Existing non-null/strict-zero semantics.
+    assert.equal(classes.has("hide-col-evo"), true); // The threshold is strictly greater than 0.05.
+});

--- a/frontend/tests/combo-view.test.js
+++ b/frontend/tests/combo-view.test.js
@@ -139,6 +139,28 @@ test("empty results clear old rows and remain empty when sorted or cached", asyn
     assert.match(v.nodes.get("attachment-body").innerHTML, /ui.comboNone/);
 });
 
+for (const changeContext of [
+    state => { state.currentGun = null; state.buildTree = null; state.lastSlot = null; state.lastParentNode = null; },
+    state => { state.buildTree = { item: state.currentGun, children: {} }; },
+    state => { state.currentStrengthLevel = 51; },
+    state => { state.currentEquipErgoModifier = -0.1; },
+]) {
+    test("a changed gun, tab or stat context discards the pending result", async () => {
+        const v = view(), request = v.select("A");
+        changeContext(v.state);
+        v.pending[0].onProgress({ capped: true });
+        assert.equal(v.nodes.has("combo-loading-progress"), false);
+        v.pending[0].resolve(result("A", true));
+        await request;
+        assert.equal(v.state.lastComboItems.length, 0);
+        assert.equal(Object.keys(v.state.combosCache).length, 0);
+        assert.equal(v.toasts.length, 0);
+        assert.equal(v.errors.length, 0);
+        assert.equal(v.inFlight(), false);
+        assert.equal(v.intervals.size, 0);
+    });
+}
+
 for (const value of [
     { ...result("A"), response_format: "future" },
     { ...compact(result("A")), items: {} },

--- a/frontend/tests/combo-view.test.js
+++ b/frontend/tests/combo-view.test.js
@@ -142,10 +142,8 @@ test("empty results clear old rows and remain empty when sorted or cached", asyn
 for (const changeContext of [
     state => { state.currentGun = null; state.buildTree = null; state.lastSlot = null; state.lastParentNode = null; },
     state => { state.buildTree = { item: state.currentGun, children: {} }; },
-    state => { state.currentStrengthLevel = 51; },
-    state => { state.currentEquipErgoModifier = -0.1; },
 ]) {
-    test("a changed gun, tab or stat context discards the pending result", async () => {
+    test("a changed gun or tab discards the pending result", async () => {
         const v = view(), request = v.select("A");
         changeContext(v.state);
         v.pending[0].onProgress({ capped: true });
@@ -156,6 +154,30 @@ for (const changeContext of [
         assert.equal(Object.keys(v.state.combosCache).length, 0);
         assert.equal(v.toasts.length, 0);
         assert.equal(v.errors.length, 0);
+        assert.equal(v.inFlight(), false);
+        assert.equal(v.intervals.size, 0);
+    });
+}
+
+for (const [field, value, requestField] of [
+    ["currentStrengthLevel", 51, "strength_level"],
+    ["currentEquipErgoModifier", -0.1, "equip_ergo_modifier"],
+]) for (const failed of [false, true]) {
+    test("changed stat inputs restart the current view after an outdated response or error", async () => {
+        const v = view(), request = v.select("A");
+        v.state[field] = value;
+        if (failed) v.pending[0].reject(new Error("outdated failure"));
+        else v.pending[0].resolve(result("old", true));
+        await new Promise(resolve => setImmediate(resolve));
+        assert.equal(v.pending.length, 2);
+        assert.equal(v.pending[1].payload[requestField], value);
+        assert.equal(v.inFlight(), true);
+        assert.equal(v.toasts.length, 0);
+        assert.equal(v.errors.length, 0);
+        v.pending[1].resolve(result("current"));
+        await request;
+        assert.equal(v.state.lastComboItems[0].parentEntry.item.id, "current");
+        assert.equal(Object.keys(v.state.combosCache).length, 1);
         assert.equal(v.inFlight(), false);
         assert.equal(v.intervals.size, 0);
     });


### PR DESCRIPTION
This follow-up to #38 substantially reduces the cost of delivering large Combo results: **83.6% less uncompressed data and approximately 5.2× faster backend result encoding** in the 51,820-combo M4 stress case.

| Measurement | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Uncompressed result payload | 281.5 MB | 46.1 MB | **83.6% smaller** |
| Cached-result encoding | 2.19 s | 0.42 s | **~5.2× faster** |

That removes approximately **235 MB from each uncompressed response**, substantially reducing the transfer burden after calculation. All 51,820 combinations, their ordering, stats, installation paths, and conflict information are preserved. The smaller M4 stock case also sees a **64.2% payload reduction**.

Measurements use the same fixed dataset. The large case covers the M4 receiver/barrel branch with handguards excluded; encoding times are three-run medians.

The implementation adds compact responses, incremental SSE parsing, and shared item metadata during result preparation. It also handles stale responses and recalculates when inputs change. Legacy compatibility, solver limits, and truncation behavior are preserved.

Validated with **106 backend tests, 48 frontend tests, 192 sorting/filtering equivalence checks**, and six desktop/mobile smoke scenarios.

[CI](https://github.com/PainAxis/EFTForge/actions/runs/34128560641) · [Cloudflare smoke tests](https://github.com/PainAxis/EFTForge/actions/runs/34104351112)