### PR TITLE
fix(optimizer): account for loaded ammo weight and reuse sparse constraints

### DIFF
--- a/backend/benchmarks/README.md
+++ b/backend/benchmarks/README.md
@@ -1,5 +1,47 @@
 # Solver baselines
 
+## Loaded-ammo A/B comparison
+
+`optimizer_ammo_ab.py` compares two backend checkouts against one read-only
+database snapshot. It runs twelve M4A1 cases covering weighted-sum,
+Tchebycheff and EvoErgo modes, empty/loaded magazines, overswing prevention,
+suppressors and weight limits. All cases require at least a 60-round magazine.
+
+```bash
+python benchmarks/optimizer_ammo_ab.py \
+  --baseline /path/to/baseline/backend --candidate /path/to/candidate/backend \
+  --database /path/to/synced/tarkov.db --output /path/to/new-results-dir --runs 5
+```
+
+The two workers stay resident, but only one solve runs at a time. Each case
+gets one untimed warm-up pair followed by alternating A/B pairs; case order
+is shuffled reproducibly. Imports, garbage collection and result validation
+are outside the timed region. Candidate loading, solving and final statistics
+are timed, bypassing the HTTP result cache. Workers use `PYTHONHASHSEED=0`
+(override with `--hash-seed`) and one BLAS/OpenMP thread; HiGHS options retain
+the application's defaults. Repeat `--case` to focus a follow-up comparison.
+
+`metadata.json` records input/source hashes, runtime versions and graph shape.
+`samples.jsonl` preserves every measurement, including warm-ups, solver phase
+timings, solve counts, selections and validation against builder statistics.
+`summary.json` reports medians, ranges and constraint violations. Compare
+empty-magazine cases for implementation overhead; loaded-ammo cases may
+legitimately search different models and must also be checked for correctness.
+An old build that violates a loaded-weight constraint is not an equivalent
+faster solution. Five repetitions describe local behavior, not a timing SLA.
+
+For performance-only follow-ups, use a baseline that already includes the
+loaded-ammo correction. This separates faster execution from changes to the
+feasible builds. Check result digests as well as the constraint checks above.
+The sparse-matrix follow-up keeps every row, coefficient, objective, tangent
+anchor, solve limit and solver option unchanged: `ConstraintBuilder` emits CSC
+directly and reuses it for repeated objectives until another row is appended.
+The cache is local to that builder in that request; new overswing cuts rebuild
+it, and axis-specific constraint copies keep independent caches.
+`matrix_build_ms` times the builder itself; `solver_ms` also includes SciPy's
+input conversion, so avoiding repeated dense-to-sparse conversion reduces that
+phase without changing HiGHS search settings or the number of solves.
+
 `solver_baseline.py` measures solvers from a cold result cache against fixed,
 real-data cases:
 

--- a/backend/benchmarks/optimizer_ammo_ab.py
+++ b/backend/benchmarks/optimizer_ammo_ab.py
@@ -1,0 +1,302 @@
+"""Alternate two persistent workers against one read-only M4A1 DB snapshot.
+
+The timed region includes candidate loading, solving and final stats. It bypasses
+the HTTP result cache. Worker imports, GC and validation are outside that region.
+"""
+
+import argparse
+from collections import deque
+import gc
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import random
+import statistics
+import subprocess
+import sys
+import time
+
+WEAPON = "5447a9cd4bdc2dbd208b4567"
+AMMO = "54527a984bdc2d4e668b4567"  # M855, 0.012 kg
+CASES = {
+    "weighted_empty": {"use_tchebycheff": False, "assume_full_mag": False},
+    "weighted_loaded": {"use_tchebycheff": False},
+    "default_empty": {"assume_full_mag": False},
+    "default_loaded": {},
+    "evo_empty": {"use_evo_ergo": True, "assume_full_mag": False},
+    "evo_loaded": {"use_evo_ergo": True},
+    "recoil_overswing_empty": {
+        "ergo_weight": 0,
+        "prevent_overswing": True,
+        "assume_full_mag": False,
+    },
+    "recoil_overswing_loaded": {"ergo_weight": 0, "prevent_overswing": True},
+    "evo_overswing_loaded": {"use_evo_ergo": True, "prevent_overswing": True},
+    "evo_suppressed_overswing": {
+        "use_evo_ergo": True,
+        "ergo_weight": 0,
+        "prevent_overswing": True,
+        "require_suppressor": True,
+    },
+    "default_weight_limit": {"max_weight": 4.0, "ergo_weight": 0},
+    "evo_weight_limit": {"max_weight": 4.0, "use_evo_ergo": True},
+}
+
+
+def digest(value):
+    return hashlib.sha256(json.dumps(value, sort_keys=True).encode()).hexdigest()
+
+
+def graph_metrics(cmap):
+    placements = {}
+    for sid, ids in cmap.slot_items.items():
+        for iid in ids:
+            placements.setdefault(iid, set()).add(sid)
+    depth = {WEAPON: 0}
+    queue = deque([WEAPON])
+    while queue:
+        owner = queue.popleft()
+        for sid in cmap.item_to_slots.get(owner, []):
+            for iid in cmap.slot_items[sid]:
+                if iid not in depth:
+                    depth[iid] = depth[owner] + 1
+                    queue.append(iid)
+    return {
+        "reachable": len(cmap.reachable_ids),
+        "multi_parent": sum(len(slots) > 1 for slots in placements.values()),
+        "slots": len(cmap.slot_items),
+        "edges": sum(len(ids) for ids in cmap.slot_items.values()),
+        "max_shortest_depth": max(depth.values()),
+    }
+
+
+def worker(args):
+    started = time.perf_counter()
+    sys.path.insert(0, str(args.backend.resolve()))
+    import scipy
+    import sqlalchemy
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import Session
+    from models_items import Item
+    from optimizer.compat_map import build_compatibility_map
+    from optimizer.solver import OptimizeParams, optimize_weapon
+    from stats import _compute_stats, apply_full_mag_ammo
+
+    engine = create_engine(f"sqlite:///file:{args.database.resolve()}?mode=ro&uri=true")
+    with Session(engine) as db:
+        graph = graph_metrics(build_compatibility_map(db, WEAPON))
+    assert graph["reachable"] >= 500 and graph["multi_parent"] >= 400
+    source_hashes = {
+        name: hashlib.sha256((args.backend / name).read_bytes()).hexdigest()
+        for name in ("optimizer/milp.py", "optimizer/solver.py", "stats.py")
+    }
+    print(
+        json.dumps(
+            {
+                "python": sys.version,
+                "scipy": scipy.__version__,
+                "sqlalchemy": sqlalchemy.__version__,
+                "graph": graph,
+                "source_hashes": source_hashes,
+                "startup_ms": (time.perf_counter() - started) * 1000,
+            }
+        ),
+        flush=True,
+    )
+    for line in sys.stdin:
+        request = json.loads(line)
+        params = OptimizeParams(**request["params"])
+        gc.collect()
+        with Session(engine) as db:
+            cpu = time.process_time()
+            started = time.perf_counter()
+            result = optimize_weapon(db, WEAPON, params)
+            wall_ms = (time.perf_counter() - started) * 1000
+            cpu_ms = (time.process_time() - cpu) * 1000
+            checks = {}
+            selected = result.get("selected_items", [])
+            if result["status"] in ("optimal", "feasible"):
+                mods = {iid: db.get(Item, iid) for iid in selected}
+                expected = _compute_stats(
+                    db.get(Item, WEAPON), selected, mods, params.strength_level, params.equip_ergo_modifier
+                )
+                ammo = db.get(Item, params.selected_ammo_id) if params.assume_full_mag else None
+                apply_full_mag_ammo(expected, mods, ammo, None, params.strength_level, params.equip_ergo_modifier)
+                checks = {
+                    "stats_match_builder": expected == result["final_stats"],
+                    "overswing_constraint": not params.prevent_overswing or not expected["overswing"],
+                    "weight_constraint": params.max_weight is None or expected["total_weight"] <= params.max_weight,
+                    "magazine_constraint": max((m.magazine_capacity or 0) for m in mods.values())
+                    >= params.min_mag_capacity,
+                }
+        stable = {k: result.get(k) for k in ("status", "final_stats", "total_price_rub", "ammo_fill")}
+        stable["selected_items"] = sorted(selected)
+        print(
+            json.dumps(
+                {
+                    "wall_ms": wall_ms,
+                    "cpu_ms": cpu_ms,
+                    "status": result["status"],
+                    "metrics": result.get("metrics", {}),
+                    "final_stats": result.get("final_stats"),
+                    "ammo_fill": result.get("ammo_fill"),
+                    "selected_items": sorted(selected),
+                    "digest": digest(stable),
+                    "checks": checks,
+                }
+            ),
+            flush=True,
+        )
+
+
+def summarize(records):
+    out = {}
+    for case in sorted({r["case"] for r in records}):
+        out[case] = {}
+        for revision in ("baseline", "candidate"):
+            rows = [r for r in records if r["case"] == case and r["revision"] == revision and r["phase"] == "measured"]
+            if not rows:
+                continue
+            values = [r["wall_ms"] for r in rows]
+            out[case][revision] = {
+                "n": len(rows),
+                "median_ms": statistics.median(values),
+                "min_ms": min(values),
+                "max_ms": max(values),
+                "median_cpu_ms": statistics.median(r["cpu_ms"] for r in rows),
+                "metrics_median": {
+                    k: statistics.median(r["metrics"].get(k, 0) for r in rows)
+                    for k in ("candidate_load_ms", "model_build_ms", "matrix_build_ms", "solver_ms", "solve_count")
+                },
+                "statuses": sorted({r["status"] for r in rows}),
+                "digests": sorted({r["digest"] for r in rows}),
+                "invalid_results": sum(not all(r["checks"].values()) for r in rows),
+                "last_stats": rows[-1]["final_stats"],
+            }
+    return out
+
+
+def controller(args):
+    args.output.mkdir(parents=True, exist_ok=False)
+    selected = args.case or list(CASES)
+    params = {
+        name: {
+            "selected_ammo_id": AMMO,
+            "assume_full_mag": True,
+            "min_mag_capacity": 60,
+            "ergo_weight": 1,
+            "recoil_weight": 1,
+            "price_weight": 0,
+            **CASES[name],
+        }
+        for name in selected
+    }
+    env = {
+        **os.environ,
+        "PYTHONHASHSEED": str(args.hash_seed),
+        "IP_HASH_SECRET": "ammo-benchmark-only",
+        "ADMIN_API_KEY": "ammo-benchmark-only",
+        "DISABLE_BG_MIGRATE": "1",
+        "OPENBLAS_NUM_THREADS": "1",
+        "OMP_NUM_THREADS": "1",
+        "MKL_NUM_THREADS": "1",
+    }
+    processes, logs, metadata, records = {}, [], {}, []
+    try:
+        for name, backend in (("baseline", args.baseline), ("candidate", args.candidate)):
+            log = (args.output / f"{name}.stderr.log").open("w")
+            logs.append(log)
+            processes[name] = subprocess.Popen(
+                [
+                    sys.executable,
+                    str(Path(__file__).resolve()),
+                    "--worker",
+                    "--backend",
+                    str(backend.resolve()),
+                    "--database",
+                    str(args.database.resolve()),
+                ],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=log,
+                text=True,
+                env=env,
+            )
+            metadata[name] = json.loads(processes[name].stdout.readline())
+        assert metadata["baseline"]["graph"] == metadata["candidate"]["graph"]
+        metadata.update(
+            {
+                "database_sha256": hashlib.sha256(args.database.read_bytes()).hexdigest(),
+                "cases": params,
+                "runs": args.runs,
+                "hash_seed": args.hash_seed,
+                "platform": platform.platform(),
+                "cpu_count": os.cpu_count(),
+                "cpu_affinity": sorted(os.sched_getaffinity(0)) if hasattr(os, "sched_getaffinity") else None,
+                "thread_env": {k: env[k] for k in ("OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS", "MKL_NUM_THREADS")},
+            }
+        )
+        (args.output / "metadata.json").write_text(json.dumps(metadata, indent=2))
+        with (args.output / "samples.jsonl").open("w") as stream:
+            rng = random.Random(37)
+            for round_id in range(args.runs + 1):
+                order = selected.copy()
+                rng.shuffle(order)
+                for case_index, case in enumerate(order):
+                    revisions = (
+                        ["baseline", "candidate"] if (round_id + case_index) % 2 == 0 else ["candidate", "baseline"]
+                    )
+                    pair = {}
+                    for revision in revisions:
+                        proc = processes[revision]
+                        proc.stdin.write(json.dumps({"params": params[case]}) + "\n")
+                        proc.stdin.flush()
+                        line = proc.stdout.readline()
+                        if not line:
+                            raise RuntimeError(f"{revision} worker stopped; see its stderr log")
+                        row = {
+                            "case": case,
+                            "round": round_id,
+                            "phase": "warmup" if round_id == 0 else "measured",
+                            "revision": revision,
+                            **json.loads(line),
+                        }
+                        records.append(row)
+                        stream.write(json.dumps(row) + "\n")
+                        stream.flush()
+                        pair[revision] = round(row["wall_ms"], 1)
+                    print(json.dumps({"round": round_id, "case": case, **pair}), flush=True)
+        (args.output / "summary.json").write_text(json.dumps(summarize(records), indent=2))
+    finally:
+        for process in processes.values():
+            if process.poll() is None:
+                process.stdin.close()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.terminate()
+                    process.wait(timeout=5)
+        for log in logs:
+            log.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--backend", type=Path, help=argparse.SUPPRESS)
+    parser.add_argument("--baseline", type=Path)
+    parser.add_argument("--candidate", type=Path)
+    parser.add_argument("--database", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--runs", type=int, default=5)
+    parser.add_argument("--hash-seed", type=int, default=0)
+    parser.add_argument("--case", action="append", choices=CASES)
+    args = parser.parse_args()
+    if args.worker:
+        worker(args)
+    else:
+        if not args.baseline or not args.candidate or not args.output or args.runs < 1:
+            parser.error("--baseline, --candidate, --output and --runs >= 1 are required")
+        controller(args)

--- a/backend/optimizer/milp.py
+++ b/backend/optimizer/milp.py
@@ -11,8 +11,9 @@ from types import SimpleNamespace
 
 import numpy as np
 from scipy.optimize import milp, LinearConstraint, Bounds
+from scipy.sparse import csc_array
 
-from stats import _compute_stats
+from stats import _compute_stats, apply_full_mag_ammo, full_mag_ammo_weight
 
 TIEBREAK = 0.01
 
@@ -127,12 +128,45 @@ class _Infeasible(Exception):
         self.params = params or {}
 
 
+class _SolveStats:
+    """Request-local loaded weights and exact stats, without modifying item records.
+
+    Linear coefficients include ammo per candidate. Exact checks use the original
+    records plus the shared ammo calculation, preserving factory-preset stats and
+    the same rounding as the main builder.
+    """
+
+    def __init__(self, weapon, mods, params, ammo=None, ubgl_grenade=None):
+        self.weapon = weapon
+        self.mods = mods
+        self.strength_level = params.strength_level
+        self.equip_ergo_modifier = params.equip_ergo_modifier
+        self.ammo = ammo
+        self.ubgl_grenade = ubgl_grenade
+        self.item_weights = {
+            iid: (item.weight or 0) + full_mag_ammo_weight(item, ammo, ubgl_grenade) for iid, item in mods.items()
+        }
+
+    def compute(self, selected_ids):
+        stats = _compute_stats(self.weapon, selected_ids, self.mods, self.strength_level, self.equip_ergo_modifier)
+        selected_mods = {iid: self.mods[iid] for iid in selected_ids}
+        return apply_full_mag_ammo(
+            stats, selected_mods, self.ammo, self.ubgl_grenade, self.strength_level, self.equip_ergo_modifier
+        )
+
+
 class ConstraintBuilder:
-    """Accumulates (coeffs, lb, ub) rows, then assembles one LinearConstraint."""
+    """Append-only rows, compiled to the sparse format HiGHS consumes.
+
+    Objectives change many times in an EvoErgo sweep without changing the
+    constraints. Reuse that matrix until a new overswing cut is appended.
+    """
 
     def __init__(self, n):
         self.n = n
         self.rows = []
+        self._compiled = None
+        self._compiled_row_count = 0
 
     def le(self, coeffs: dict, rhs):
         self.rows.append((coeffs, -np.inf, rhs))
@@ -146,15 +180,23 @@ class ConstraintBuilder:
     def build(self):
         if not self.rows:
             return None
-        A = np.zeros((len(self.rows), self.n))
-        lb = np.zeros(len(self.rows))
-        ub = np.zeros(len(self.rows))
+        if self._compiled_row_count == len(self.rows):
+            return self._compiled
+        row_indices, col_indices, values = [], [], []
+        lb = np.empty(len(self.rows))
+        ub = np.empty(len(self.rows))
         for row_i, (coeffs, l, u) in enumerate(self.rows):
             for col_i, val in coeffs.items():
-                A[row_i, col_i] += val
+                if val:
+                    row_indices.append(row_i)
+                    col_indices.append(col_i)
+                    values.append(val)
             lb[row_i] = l
             ub[row_i] = u
-        return LinearConstraint(A, lb, ub)
+        A = csc_array((values, (row_indices, col_indices)), shape=(len(self.rows), self.n), dtype=float)
+        self._compiled = LinearConstraint(A, lb, ub)
+        self._compiled_row_count = len(self.rows)
+        return self._compiled
 
 
 def _order_pairs_parent_first(selected_ids, item_to_valid_slots, weapon_id, selected_set):
@@ -228,7 +270,9 @@ def _lp_stat_range(cb, n, coeffs):
     return lo, hi
 
 
-def _add_overswing_cut_at(cb, idx, mods, item_ids, base_ergo, base_weight, equip_ergo_modifier, anchor_ergo):
+def _add_overswing_cut_at(
+    cb, idx, mods, item_ids, base_ergo, base_weight, equip_ergo_modifier, anchor_ergo, solve_stats=None
+):
     """Adds one linear tangent-line cut - total_weight <= KG(effective_ergo)'s
     tangent at anchor_ergo - hard-constraining out exactly the build that sits
     at that ergo value and everything else the tangent's slope excludes. KG is
@@ -243,7 +287,11 @@ def _add_overswing_cut_at(cb, idx, mods, item_ids, base_ergo, base_weight, equip
     e0 = anchor_ergo * (1 + b)
     kg0 = KG_A * e0 * e0 + KG_B * e0 + KG_C
     slope = (2 * KG_A * e0 + KG_B) * (1 + b)  # d(KG)/d(total_ergo) via chain rule E = total_ergo*(1+b)
-    coeffs = {idx[i]: (mods[i].weight or 0) - slope * (mods[i].ergonomics_modifier or 0) for i in item_ids}
+    coeffs = {
+        idx[i]: (solve_stats.item_weights[i] if solve_stats else (mods[i].weight or 0))
+        - slope * (mods[i].ergonomics_modifier or 0)
+        for i in item_ids
+    }
     rhs = kg0 + slope * (base_ergo - anchor_ergo) - base_weight
     cb.le(coeffs, rhs)
 
@@ -287,7 +335,7 @@ def _add_max_moa_constraint(cb, idx, mods, weapon, item_ids, max_moa):
         cb.ge(coeffs, MOA_K * weapon.center_of_impact - max_moa)
 
 
-def _build_constraints(weapon, mods: dict, compat_map, candidate_ids: list, prices: dict, params):
+def _build_constraints(weapon, mods: dict, compat_map, candidate_ids: list, prices: dict, params, solve_stats=None):
     """Builds every item_id/idx/constraint/item_to_valid_slots the solve needs,
     independent of the objective - so the EvoErgo sweep can re-solve the same
     model with different objectives without rebuilding constraints each time.
@@ -470,7 +518,10 @@ def _build_constraints(weapon, mods: dict, compat_map, candidate_ids: list, pric
         cb.ge({idx[i]: 1 for i in suppressors}, 1)
 
     if params.max_weight is not None:
-        cb.le({idx[i]: (mods[i].weight or 0) for i in item_ids}, params.max_weight - base_weight)
+        cb.le(
+            {idx[i]: solve_stats.item_weights[i] if solve_stats else (mods[i].weight or 0) for i in item_ids},
+            params.max_weight - base_weight,
+        )
 
     if params.min_mag_capacity:
         mags = [i for i in item_ids if (mods[i].magazine_capacity or 0) >= params.min_mag_capacity]
@@ -532,7 +583,7 @@ def _weighted_objective(item_ids, idx, mods, prices, params):
     return c
 
 
-def _evo_ergo_objective(k, item_ids, idx, mods, prices, params):
+def _evo_ergo_objective(k, item_ids, idx, mods, prices, params, solve_stats=None):
     """Same blended objective as _weighted_objective, on the exact same
     exchange rates (ERGO_OBJ_COEFF/RECOIL_OBJ_COEFF/PRICE_OBJ_COEFF), except
     the raw ergo term is replaced with a tangent-linearized EvoErgo term (ergo
@@ -556,9 +607,8 @@ def _evo_ergo_objective(k, item_ids, idx, mods, prices, params):
     c = np.zeros(len(item_ids) + 1)
     for item_id in item_ids:
         i = idx[item_id]
-        evo_ergo_term = (
-            ergo_w * ERGO_OBJ_COEFF * (-k * (mods[item_id].ergonomics_modifier or 0) + 15 * (mods[item_id].weight or 0))
-        )
+        weight = solve_stats.item_weights[item_id] if solve_stats else (mods[item_id].weight or 0)
+        evo_ergo_term = ergo_w * ERGO_OBJ_COEFF * (-k * (mods[item_id].ergonomics_modifier or 0) + 15 * weight)
         recoil_term = recoil_w * RECOIL_OBJ_COEFF * (mods[item_id].recoil_modifier or 0)
         price_term = price_w * PRICE_OBJ_COEFF * prices[item_id]["price_rub"]
         c[i] = evo_ergo_term + recoil_term + price_term
@@ -572,7 +622,7 @@ def _evo_ergo_k_for_anchor(ergo_anchor, equip_ergo_modifier):
     return 15 * kg_prime * (1 + b)  # chain rule through E = ergo*(1+b)
 
 
-def _evo_ergo_true_score(candidate, weapon, mods, params):
+def _evo_ergo_true_score(candidate, weapon, mods, params, solve_stats=None):
     """The exact value of the same blended objective _evo_ergo_objective's
     tangent line only approximates for a given candidate build - true
     (quadratic) EED in place of the linearized guess, recoil/price read
@@ -610,9 +660,14 @@ def _evo_ergo_true_score(candidate, weapon, mods, params):
     ergo_w = max(params.ergo_weight, WEIGHT_FLOOR)
     recoil_w = max(params.recoil_weight, WEIGHT_FLOOR)
     price_w = max(params.price_weight, WEIGHT_FLOOR)
-    eed = _compute_stats(weapon, candidate["selected_items"], mods, params.strength_level, params.equip_ergo_modifier)[
-        "evo_ergo_delta"
-    ]
+    stats = (
+        solve_stats.compute(candidate["selected_items"])
+        if solve_stats
+        else _compute_stats(
+            weapon, candidate["selected_items"], mods, params.strength_level, params.equip_ergo_modifier
+        )
+    )
+    eed = stats["evo_ergo_delta"]
     recoil_sum = sum((mods[i].recoil_modifier or 0) for i in candidate["selected_items"])
     return (
         -ergo_w * ERGO_OBJ_COEFF * eed
@@ -790,6 +845,7 @@ def _solve_avoiding_overswing(
     strength_level,
     deadline=None,
     extra_bounds=(100.0,),
+    solve_stats=None,
 ):
     """Same contract as _solve_once, but hard-constrains the result to
     stats.py's own "overswing" definition (total_weight <= KG(effective_ergo))
@@ -818,7 +874,11 @@ def _solve_avoiding_overswing(
         if result["status"] not in ("optimal", "feasible"):
             result["metrics"] = _aggregate_attempt_metrics(attempts)
             return result
-        stats = _compute_stats(weapon, result["selected_items"], mods, strength_level, equip_ergo_modifier)
+        stats = (
+            solve_stats.compute(result["selected_items"])
+            if solve_stats
+            else _compute_stats(weapon, result["selected_items"], mods, strength_level, equip_ergo_modifier)
+        )
         if not stats["overswing"]:
             incomplete = any(attempt["status"] != "optimal" for attempt in attempts)
             if incomplete:
@@ -835,7 +895,9 @@ def _solve_avoiding_overswing(
             result["metrics"] = _aggregate_attempt_metrics(attempts)
             return result
         selected_ergo = base_ergo + sum((mods[i].ergonomics_modifier or 0) for i in result["selected_items"])
-        _add_overswing_cut_at(cb, idx, mods, item_ids, base_ergo, base_weight, equip_ergo_modifier, selected_ergo)
+        _add_overswing_cut_at(
+            cb, idx, mods, item_ids, base_ergo, base_weight, equip_ergo_modifier, selected_ergo, solve_stats
+        )
     reason = "Overswing constraint cut iteration limit reached before finding a feasible build."
     return _empty_result(
         "error",
@@ -896,7 +958,19 @@ def _candidate_axis_values(candidate, mods, prices, base_ergo):
 
 
 def _compute_ideal_and_nadir(
-    cb, n, item_ids, idx, mods, prices, weapon, item_to_valid_slots, base_ergo, base_weight, params, deadline
+    cb,
+    n,
+    item_ids,
+    idx,
+    mods,
+    prices,
+    weapon,
+    item_to_valid_slots,
+    base_ergo,
+    base_weight,
+    params,
+    deadline,
+    solve_stats=None,
 ):
     """One pure single-axis solve per axis (ergo/recoil/price) finds that
     axis's ideal point; the *other* two axes' values on those same builds
@@ -938,6 +1012,7 @@ def _compute_ideal_and_nadir(
                 params.equip_ergo_modifier,
                 params.strength_level,
                 deadline=deadline,
+                solve_stats=solve_stats,
             )
         else:
             candidate = _solve_once(c, cb, n, item_ids, weapon.id, item_to_valid_slots, prices, deadline=deadline)
@@ -1018,7 +1093,19 @@ def _tchebycheff_model(cb, n, item_ids, idx, mods, prices, ideal, nadir, params)
 
 
 def _solve_tchebycheff(
-    cb, n, item_ids, idx, mods, prices, weapon, item_to_valid_slots, base_ergo, base_weight, params, deadline
+    cb,
+    n,
+    item_ids,
+    idx,
+    mods,
+    prices,
+    weapon,
+    item_to_valid_slots,
+    base_ergo,
+    base_weight,
+    params,
+    deadline,
+    solve_stats=None,
 ):
     """Top-level Tchebycheff solve: compute ideal/nadir, build the augmented
     min-max model, solve it. Falls back to signaling "no ideal point" (via a
@@ -1026,7 +1113,19 @@ def _solve_tchebycheff(
     weighted-sum rather than scalarize against a broken reference point.
     """
     ideal, nadir, ideal_attempts = _compute_ideal_and_nadir(
-        cb, n, item_ids, idx, mods, prices, weapon, item_to_valid_slots, base_ergo, base_weight, params, deadline
+        cb,
+        n,
+        item_ids,
+        idx,
+        mods,
+        prices,
+        weapon,
+        item_to_valid_slots,
+        base_ergo,
+        base_weight,
+        params,
+        deadline,
+        solve_stats,
     )
     if ideal is None:
         return None, ideal_attempts
@@ -1049,6 +1148,7 @@ def _solve_tchebycheff(
             params.strength_level,
             deadline=deadline,
             extra_bounds=(100.0, TCHEBYCHEFF_Z_BOUND),
+            solve_stats=solve_stats,
         )
     else:
         result = _solve_once(
@@ -1065,12 +1165,15 @@ def _solve_tchebycheff(
     return result, ideal_attempts
 
 
-def build_and_solve(weapon, mods: dict, compat_map, candidate_ids: list, prices: dict, params):
+def build_and_solve(
+    weapon, mods: dict, compat_map, candidate_ids: list, prices: dict, params, *, ammo=None, ubgl_grenade=None
+):
     model_start = time.perf_counter()
     deadline = model_start + SOLVE_TIME_LIMIT_SECONDS
+    solve_stats = _SolveStats(weapon, mods, params, ammo, ubgl_grenade)
     try:
         item_ids, idx, cb, item_to_valid_slots, base_ergo, base_weight, base_recoil_v, _ergo_idx = _build_constraints(
-            weapon, mods, compat_map, candidate_ids, prices, params
+            weapon, mods, compat_map, candidate_ids, prices, params, solve_stats
         )
     except _Infeasible as exc:
         return {
@@ -1106,6 +1209,7 @@ def build_and_solve(weapon, mods: dict, compat_map, candidate_ids: list, prices:
                 base_weight,
                 params,
                 deadline,
+                solve_stats,
             )
             if tcheby_result is not None:
                 tcheby_result["metrics"] = {
@@ -1132,6 +1236,7 @@ def build_and_solve(weapon, mods: dict, compat_map, candidate_ids: list, prices:
                 params.equip_ergo_modifier,
                 params.strength_level,
                 deadline=deadline,
+                solve_stats=solve_stats,
             )
         else:
             result = _solve_once(c, cb, n, item_ids, weapon.id, item_to_valid_slots, prices, deadline=deadline)
@@ -1177,7 +1282,7 @@ def build_and_solve(weapon, mods: dict, compat_map, candidate_ids: list, prices:
                 # redundant, not a sign this anchor went unexplored.
                 break
             tried_k.add(rounded_k)
-            c = _evo_ergo_objective(k, item_ids, idx, mods, prices, params)
+            c = _evo_ergo_objective(k, item_ids, idx, mods, prices, params, solve_stats)
             if params.prevent_overswing:
                 candidate = _solve_avoiding_overswing(
                     c,
@@ -1194,6 +1299,7 @@ def build_and_solve(weapon, mods: dict, compat_map, candidate_ids: list, prices:
                     params.equip_ergo_modifier,
                     params.strength_level,
                     deadline=deadline,
+                    solve_stats=solve_stats,
                 )
             else:
                 candidate = _solve_once(c, cb, n, item_ids, weapon.id, item_to_valid_slots, prices, deadline=deadline)
@@ -1202,7 +1308,7 @@ def build_and_solve(weapon, mods: dict, compat_map, candidate_ids: list, prices:
                 deadline_exhausted = True
             if candidate["status"] not in ("optimal", "feasible"):
                 break
-            score = _evo_ergo_true_score(candidate, weapon, mods, params)
+            score = _evo_ergo_true_score(candidate, weapon, mods, params, solve_stats)
             if best_score is None or score < best_score:
                 best, best_score = candidate, score
             if not refine:

--- a/backend/optimizer/solver.py
+++ b/backend/optimizer/solver.py
@@ -100,10 +100,8 @@ class OptimizeParams:
     strength_level: int = 10
     equip_ergo_modifier: float = 0.0
     # Mirrors /build/calculate's "assume full mag" toggle (see stats.apply_full_mag_ammo):
-    # applied only to final_stats/evo_contributions after the solve, not to the solve's own
-    # objective/constraints - a magazine's chosen ammo isn't a build decision the MILP makes,
-    # it's the caller's existing selection from the main builder, applied the same way loading
-    # a solved build into that builder would recompute stats for it.
+    # ammo selection stays fixed, while each candidate magazine/UBGL carries its own
+    # capacity-dependent ammo weight in the objective, constraints and final stats.
     assume_full_mag: bool = True
     selected_ammo_id: Optional[str] = None
     selected_ubgl_ammo_id: Optional[str] = None
@@ -253,7 +251,19 @@ def optimize_weapon(db, weapon_id: str, params: OptimizeParams) -> dict:
             "metrics": {**input_metrics, "processing_ms": round((time.perf_counter() - started) * 1000, 3)},
         }
 
-    result = build_and_solve(weapon, mods, compat_map, candidate_ids, prices, params)
+    ammo = (
+        db.query(Item).filter(Item.id == params.selected_ammo_id).first()
+        if (params.assume_full_mag and params.selected_ammo_id)
+        else None
+    )
+    ubgl_grenade = (
+        db.query(Item).filter(Item.id == params.selected_ubgl_ammo_id).first()
+        if (params.assume_full_mag and params.selected_ubgl_ammo_id)
+        else None
+    )
+    result = build_and_solve(
+        weapon, mods, compat_map, candidate_ids, prices, params, ammo=ammo, ubgl_grenade=ubgl_grenade
+    )
     result["metrics"] = {**input_metrics, **result.get("metrics", {})}
 
     if result["status"] in ("optimal", "feasible"):
@@ -267,16 +277,6 @@ def optimize_weapon(db, weapon_id: str, params: OptimizeParams) -> dict:
         # numbers. items_map is scoped to only the selected items (not every reachable
         # candidate) since apply_full_mag_ammo scans every entry for magazine_capacity/caliber.
         selected_mods = {item_id: mods[item_id] for item_id in result["selected_items"]}
-        ammo = (
-            db.query(Item).filter(Item.id == params.selected_ammo_id).first()
-            if (params.assume_full_mag and params.selected_ammo_id)
-            else None
-        )
-        ubgl_grenade = (
-            db.query(Item).filter(Item.id == params.selected_ubgl_ammo_id).first()
-            if (params.assume_full_mag and params.selected_ubgl_ammo_id)
-            else None
-        )
         apply_full_mag_ammo(
             final_stats, selected_mods, ammo, ubgl_grenade, params.strength_level, params.equip_ergo_modifier
         )

--- a/backend/stats.py
+++ b/backend/stats.py
@@ -127,6 +127,17 @@ def _compute_stats(
     }
 
 
+def full_mag_ammo_weight(item, ammo=None, ubgl_grenade=None) -> float:
+    """Ammo carried by one installed item; selected ammo is fixed by the caller."""
+    weight = 0.0
+    if ammo and ammo.is_ammo and item.magazine_capacity:
+        weight += (ammo.weight or 0) * item.magazine_capacity
+    if ubgl_grenade and ubgl_grenade.is_ammo and ubgl_grenade.caliber:
+        if item.caliber == ubgl_grenade.caliber and not item.is_ammo:
+            weight += ubgl_grenade.weight or 0
+    return weight
+
+
 def apply_full_mag_ammo(
     stats: dict, items_map: dict, ammo, ubgl_grenade, strength_level: int, equip_ergo_modifier: float
 ) -> dict:
@@ -158,16 +169,16 @@ def apply_full_mag_ammo(
             stats["muzzle_velocity"] = round(ammo.velocity * (1 + stats["velocity_modifier_pct"] / 100))
         for att in items_map.values():
             if att.magazine_capacity:
-                stats["total_weight"] = round(stats["total_weight"] + (ammo.weight or 0) * att.magazine_capacity, 3)
+                stats["total_weight"] = round(stats["total_weight"] + full_mag_ammo_weight(att, ammo), 3)
         ammo_weight_added = True
 
     # UBGL grenade ammo weight - one round per UBGL installed. UBGLs are detected by
     # caliber-match: any non-ammo installed item whose caliber matches the selected
     # grenade ammo's caliber is the UBGL.
     if ubgl_grenade and ubgl_grenade.is_ammo and ubgl_grenade.caliber:
-        ubgl_count = sum(1 for att in items_map.values() if att.caliber == ubgl_grenade.caliber and not att.is_ammo)
-        if ubgl_count:
-            stats["total_weight"] = round(stats["total_weight"] + (ubgl_grenade.weight or 0) * ubgl_count, 3)
+        grenade_weight = sum(full_mag_ammo_weight(att, ubgl_grenade=ubgl_grenade) for att in items_map.values())
+        if grenade_weight:
+            stats["total_weight"] = round(stats["total_weight"] + grenade_weight, 3)
             ammo_weight_added = True
 
     if ammo_weight_added:

--- a/backend/tests/test_optimizer_ammo.py
+++ b/backend/tests/test_optimizer_ammo.py
@@ -1,0 +1,154 @@
+"""Loaded-ammo regressions that also run in CI without the game database."""
+
+import os
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+os.environ.setdefault("IP_HASH_SECRET", "optimizer-ammo-test-secret")
+os.environ.setdefault("ADMIN_API_KEY", "optimizer-ammo-test-admin")
+
+from database import Base
+from models_items import Item
+from optimizer.solver import OptimizeParams, optimize_weapon
+from stats import _compute_stats, apply_full_mag_ammo
+from tests.test_reachability_integration import setup_graph
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+MODES = [
+    pytest.param({"use_tchebycheff": False}, id="weighted"),
+    pytest.param({"use_tchebycheff": True}, id="tchebycheff"),
+    pytest.param({"use_evo_ergo": True}, id="evo-ergo"),
+]
+
+
+def setup_magazines(db, factory=False):
+    # The heavy build reproduces the reported X-17 numbers: 30.8 ergo,
+    # 4.392 kg empty (+1.25 EED), 4.622 kg loaded (-2.20 EED).
+    gun = {"weight": 3.982, "base_ergonomics": 30.8}
+    if factory:
+        gun.update(factory_attachment_ids="heavy", factory_weight=4.392, factory_ergonomics=30.8)
+    setup_graph(
+        db,
+        {("mag", "gun"): ["heavy", "light"]},
+        required=["mag"],
+        fields={
+            "gun": gun,
+            "heavy": {"weight": 0.410, "magazine_capacity": 10, "ergonomics_modifier": 0, "recoil_modifier": -0.1},
+            "light": {"weight": 0.210, "magazine_capacity": 10, "ergonomics_modifier": 0, "recoil_modifier": 0},
+            "ammo": {"is_ammo": True, "weight": 0.023},
+        },
+    )
+
+
+def assert_loaded_stats_match(db, result, ammo_id="ammo", grenade_id=None):
+    mods = {iid: db.get(Item, iid) for iid in result["selected_items"]}
+    expected = _compute_stats(db.get(Item, "gun"), result["selected_items"], mods)
+    apply_full_mag_ammo(
+        expected,
+        mods,
+        db.get(Item, ammo_id) if ammo_id else None,
+        db.get(Item, grenade_id) if grenade_id else None,
+        10,
+        0.0,
+    )
+    assert result["final_stats"] == expected
+
+
+@pytest.mark.parametrize("mode", MODES)
+@pytest.mark.parametrize("factory", [False, True])
+def test_prevent_overswing_checks_loaded_build(db, mode, factory):
+    setup_magazines(db, factory)
+    options = dict(mode, prevent_overswing=True, selected_ammo_id="ammo", ergo_weight=0, recoil_weight=1)
+    empty = optimize_weapon(db, "gun", OptimizeParams(**options, assume_full_mag=False))
+    assert empty["selected_items"] == ["heavy"]
+    loaded = optimize_weapon(db, "gun", OptimizeParams(**options))
+    assert loaded["status"] == "optimal"
+    assert loaded["final_stats"]["overswing"] is False
+    assert loaded["final_stats"]["evo_ergo_delta"] >= 0
+    assert loaded["selected_items"] == ["light"]
+    assert_loaded_stats_match(db, loaded)
+    # Request-local weights must not dirty ORM rows or leak into the next solve.
+    assert not db.dirty
+    assert db.get(Item, "heavy").weight == 0.410
+    again = optimize_weapon(db, "gun", OptimizeParams(**options, assume_full_mag=False))
+    assert again["final_stats"] == empty["final_stats"]
+
+
+@pytest.mark.parametrize("mode", MODES)
+def test_weight_limit_includes_ammo(db, mode):
+    setup_magazines(db)
+    options = dict(mode, max_weight=4.5, selected_ammo_id="ammo", ergo_weight=0, recoil_weight=1)
+    result = optimize_weapon(db, "gun", OptimizeParams(**options))
+    assert result["status"] == "optimal"
+    assert result["final_stats"]["total_weight"] <= 4.5
+    assert result["selected_items"] == ["light"]
+    assert_loaded_stats_match(db, result)
+
+
+@pytest.mark.parametrize("constraint", [{"max_weight": 4.5}, {"prevent_overswing": True}])
+def test_forced_overweight_loaded_build_is_infeasible(db, constraint):
+    setup_magazines(db)
+    result = optimize_weapon(db, "gun", OptimizeParams(**constraint, include_items=["heavy"], selected_ammo_id="ammo"))
+    assert result["status"] == "infeasible"
+    assert result["selected_items"] == []
+
+
+@pytest.mark.parametrize("large_mag_ergo", [0, 5])
+def test_evo_ergo_ranks_magazines_by_loaded_weight(db, large_mag_ergo):
+    setup_magazines(db)
+    db.get(Item, "gun").weight = 1.0
+    db.get(Item, "light").magazine_capacity = 60
+    # At +5 ergo, high and low tangent anchors find different magazines.
+    # The final candidate ranking must use loaded EED as well as the objective.
+    db.get(Item, "light").ergonomics_modifier = large_mag_ergo
+    db.get(Item, "heavy").recoil_modifier = 0
+    db.commit()
+    options = dict(use_evo_ergo=True, ergo_weight=1, recoil_weight=0, selected_ammo_id="ammo")
+    empty = optimize_weapon(db, "gun", OptimizeParams(**options, assume_full_mag=False))
+    loaded = optimize_weapon(db, "gun", OptimizeParams(**options))
+    assert empty["selected_items"] == ["light"]
+    assert loaded["selected_items"] == ["heavy"]
+    assert_loaded_stats_match(db, loaded)
+
+
+@pytest.mark.parametrize("ammo_id", [None, "missing", "light"])
+def test_missing_or_non_ammo_selection_keeps_empty_weight(db, ammo_id):
+    setup_magazines(db)
+    result = optimize_weapon(
+        db, "gun", OptimizeParams(prevent_overswing=True, selected_ammo_id=ammo_id, ergo_weight=0, recoil_weight=1)
+    )
+    assert result["status"] == "optimal"
+    assert result["selected_items"] == ["heavy"]
+    assert result["final_stats"]["total_weight"] == 4.392
+
+
+@pytest.mark.parametrize("mode", MODES)
+def test_ubgl_grenade_participates_in_overswing_constraint(db, mode):
+    setup_magazines(db)
+    for iid in ["heavy", "light"]:
+        item = db.get(Item, iid)
+        item.magazine_capacity = None
+        item.caliber = "Caliber40x46"
+    db.get(Item, "ammo").caliber = "Caliber40x46"
+    db.get(Item, "ammo").weight = 0.230
+    db.commit()
+    result = optimize_weapon(
+        db,
+        "gun",
+        OptimizeParams(**mode, prevent_overswing=True, selected_ubgl_ammo_id="ammo", ergo_weight=0, recoil_weight=1),
+    )
+    assert result["status"] == "optimal"
+    assert result["final_stats"]["overswing"] is False
+    assert result["selected_items"] == ["light"]
+    assert_loaded_stats_match(db, result, ammo_id=None, grenade_id="ammo")

--- a/backend/tests/test_optimizer_solver.py
+++ b/backend/tests/test_optimizer_solver.py
@@ -20,6 +20,7 @@ import pytest
 M4A1_ID = "5447a9cd4bdc2dbd208b4567"
 AK74N_ID = "5644bd2b4bdc2d3b4c8b4572"
 SVDS_ID = "5c46fbd72e2216398b5a8c9c"
+X17_ID = "676176d362e0497044079f4c"
 
 _HAS_DB = os.path.exists(os.path.join(os.path.dirname(__file__), "..", "tarkov.db"))
 
@@ -93,7 +94,8 @@ class TestAssumeFullMagAmmo:
         bare = optimize_weapon(db, M4A1_ID, OptimizeParams(min_mag_capacity=60))
         loaded = optimize_weapon(db, M4A1_ID, OptimizeParams(min_mag_capacity=60, selected_ammo_id=self.AMMO_ID))
         assert bare["status"] == loaded["status"] == "optimal"
-        assert loaded["selected_items"] == bare["selected_items"]  # ammo doesn't change which parts are chosen
+        # Plain mode without weight constraints still chooses the same parts.
+        assert loaded["selected_items"] == bare["selected_items"]
 
         from models_items import Item
 
@@ -121,6 +123,34 @@ class TestAssumeFullMagAmmo:
         assert result["status"] == "optimal"
         assert result["final_stats"]["muzzle_velocity"] is None
         assert result["ammo_fill"] is None
+
+    @pytest.mark.parametrize("use_evo_ergo,use_tchebycheff", [(False, False), (False, True), (True, True)])
+    def test_x17_m62_full_mag_respects_prevent_overswing(self, db, use_evo_ergo, use_tchebycheff):
+        """#37 follow-up: empty X-17 passed the constraint, but its ten M62
+        rounds pushed the returned build to negative EED while still 'optimal'."""
+        from models_items import Item
+
+        ammo_id = "5a608bf24f39f98ffc77720e"
+        params = OptimizeParams(
+            use_evo_ergo=use_evo_ergo,
+            use_tchebycheff=use_tchebycheff,
+            ergo_weight=0,
+            recoil_weight=1,
+            prevent_overswing=True,
+            assume_full_mag=True,
+            selected_ammo_id=ammo_id,
+            min_mag_capacity=10,  # Keep a loaded magazine; the root slot itself is optional.
+        )
+        result = optimize_weapon(db, X17_ID, params)
+        assert result["status"] == "optimal"
+        assert result["final_stats"]["overswing"] is False
+        assert result["final_stats"]["evo_ergo_delta"] >= 0
+        assert result["ammo_fill"]["capacity"] >= 10
+        weapon = db.get(Item, X17_ID)
+        mods = {m.id: m for m in db.query(Item).filter(Item.id.in_(result["selected_items"])).all()}
+        expected = _compute_stats(weapon, result["selected_items"], mods)
+        apply_full_mag_ammo(expected, mods, db.get(Item, ammo_id), None, 10, 0.0)
+        assert result["final_stats"] == expected
 
     def test_evo_contributions_of_non_magazine_parts_are_unaffected_by_ammo(self, db):
         """The ammo-weight delta must not leak into every other part's marginal

--- a/backend/tests/test_optimizer_sparse_constraints.py
+++ b/backend/tests/test_optimizer_sparse_constraints.py
@@ -1,0 +1,44 @@
+"""Guard constraint semantics when reusing sparse matrices across solves."""
+
+import numpy as np
+from scipy.optimize import Bounds, milp
+
+from optimizer.milp import ConstraintBuilder
+
+
+def test_new_cut_changes_solution_without_mutating_previous_matrix():
+    cb = ConstraintBuilder(3)
+    cb.ge({0: 1, 1: 1}, 1)
+    cb.le({0: 1, 1: 1, 2: 0}, 1)
+    cb.eq({2: 1}, 0)
+    original = cb.build()
+
+    def solve(constraints):
+        result = milp([1, 2, 0], bounds=Bounds(0, 1), integrality=1, constraints=constraints)
+        assert result.status == 0
+        return result.x
+
+    np.testing.assert_allclose(solve(original), [1, 0, 0])
+    np.testing.assert_allclose(solve(cb.build()), [1, 0, 0])
+    cb.le({0: 1}, 0)
+    np.testing.assert_allclose(solve(cb.build()), [0, 1, 0])
+    np.testing.assert_allclose(solve(original), [1, 0, 0])
+
+
+def test_empty_coefficient_row_can_still_make_model_infeasible():
+    cb = ConstraintBuilder(2)
+    cb.ge({0: 0}, 1)
+    result = milp([1, 0], bounds=Bounds(0, 1), integrality=1, constraints=cb.build())
+    assert result.status == 2
+
+
+def test_copied_constraints_keep_the_new_auxiliary_column():
+    base = ConstraintBuilder(2)
+    base.eq({0: 1, 1: 1}, 1)
+    base.build()
+    extended = ConstraintBuilder(3)
+    extended.rows.extend(base.rows)
+    extended.ge({2: 1, 0: -2, 1: -1}, 0)
+    result = milp([0, 0, 1], bounds=Bounds(0, [1, 1, 100]), integrality=[1, 1, 0], constraints=extended.build())
+    assert result.status == 0
+    np.testing.assert_allclose(result.x, [0, 1, 1])


### PR DESCRIPTION
Follow-up to #37.

Fixes the optimizer returning builds with negative loaded EED despite **Prevent Overswing** being enabled. With **Assume Full Magazine** active, ammunition weight now participates in weight limits, overswing checks, and EvoErgo scoring.

The optimizer uses the main builder’s selected ammunition as a fixed input, adding `magazine capacity × round weight`, with UBGL support. It does not select ammunition.

This PR also introduces direct sparse constraint construction and matrix reuse to reduce optimization overhead.

**Results**

M4A1 stress tests covered **579 reachable attachments**, including **418 with multiple valid parent slots**. Compared with the original solver, median request times improved:

- **Default:** 2.28 → 2.05 s (**10% faster**).
- **EvoErgo:** 2.99 → 2.18 s (**27% faster**).

Recoil priority with Prevent Overswing took 2.17 → 2.93 s (+35%; +21% with a second hash seed), while correcting the representative loaded EED from **−10.63 to +0.13**.

**Validation**

- **131 backend tests and 48 frontend tests passed**, alongside downstream CI.
- **80 A/B pairs** confirmed identical selections, statistics, and solve counts between the ammo-correct dense and sparse implementations.
- Added regression tests and a reproducible M4A1 benchmark.